### PR TITLE
switch default user id for ubuntu image

### DIFF
--- a/config/ubuntu2204.yaml
+++ b/config/ubuntu2204.yaml
@@ -1,5 +1,8 @@
 #cloud-config
 # This bootstraps a public ubuntu 2204 image from scratch.
+system_info:
+  default_user:
+    name: ec2-user
 write_files:
   - path: /tmp/bootstrap/extra-fetches.yaml
     content: |


### PR DESCRIPTION
@upodroid - would this be enough to avoid having multiple SSH_USER (one for each image)? Let's just standardize on one for all of the images on aws.

examples of this:
- https://alestic.com/2014/01/ec2-change-username/
- https://cloudinit.readthedocs.io/en/latest/reference/examples.html

