### PR TITLE
Add ec2-user to root group to allow access to containerd.sock

### DIFF
--- a/config/ubuntu2204.yaml
+++ b/config/ubuntu2204.yaml
@@ -3,6 +3,7 @@
 system_info:
   default_user:
     name: ec2-user
+    groups: root
 write_files:
   - path: /tmp/bootstrap/extra-fetches.yaml
     content: |


### PR DESCRIPTION
by default the ec2-user is not in a group that allows them access to containerd.sock, to keep it simple add that user to the `root` group