### PR TITLE
Force the old style cgroup non systemd

### DIFF
--- a/config/configure.sh
+++ b/config/configure.sh
@@ -192,6 +192,10 @@ if [ "${KUBERNETES_MASTER:-}" != "true" ]; then
 fi
 # Use systemd cgroup if specified in env
 systemdCgroup="${CONTAINERD_SYSTEMD_CGROUP:-"false"}"
+
+# FIXME(dims): FORCE systemdCgroup to false for now
+systemdCgroup=false
+
 log_level="${CONTAINERD_LOG_LEVEL:-"info"}"
 max_container_log_line="${CONTAINERD_MAX_CONTAINER_LOG_LINE:-16384}"
 cat > ${config_path} <<EOF


### PR DESCRIPTION
the amazon AMI(s) have switched off the systemd based cgroups. let's do the same for ubuntu as well.