### PR TITLE
Revert "Fix k/k path"

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-KUBE_ROOT="${KUBE_ROOT:-"$(go env GOPATH)/src/github.com/kubernetes/kubernetes"}"
-export KUBE_ROOT
+export KUBE_ROOT="$(go env GOPATH)/src/k8s.io/kubernetes"
 
 # start the cache mutation detector by default so that cache mutators will be found
 KUBE_CACHE_MUTATION_DETECTOR="${KUBE_CACHE_MUTATION_DETECTOR:-true}"


### PR DESCRIPTION
Reverts kubernetes-sigs/provider-aws-test-infra#10

I forgot I can specify a `path_alias` in the prowjob :(

```
# this was removed from the codebase but the repo references old version that can't be resolved properly on the system.
maha4472@knative-e2e:~/provider-aws-test-infra$ grep -r KubeletCredentialProviders .
./vendor/k8s.io/kubernetes/test/e2e_node/remote/node_e2e.go:	featureGateFlag := "--kubelet-flags=--feature-gates=DisableKubeletCloudCredentialProviders=true,KubeletCredentialProviders=true"
./vendor/k8s.io/kubernetes/pkg/features/kube_features.go:	KubeletCredentialProviders featuregate.Feature = "KubeletCredentialProviders"
./vendor/k8s.io/kubernetes/pkg/features/kube_features.go:	KubeletCredentialProviders: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.28
```


```
REDACTED@knative-e2e:~/go/src/sigs.k8s.io/provider-aws-test-infra$ go mod tidy
sigs.k8s.io/provider-aws-test-infra/test/e2e_node/remote/aws imports
	k8s.io/kubernetes/test/e2e_node/remote: k8s.io/kubernetes@v0.0.0: replacement directory ../../k8s.io/kubernetes does not exist
sigs.k8s.io/provider-aws-test-infra/test/e2e_node/runner/remote imports
	k8s.io/kubernetes/test/e2e_node/system: k8s.io/kubernetes@v0.0.0: replacement directory ../../k8s.io/kubernetes does not exist
sigs.k8s.io/provider-aws-test-infra/test/e2e_node/remote/aws imports
	sigs.k8s.io/yaml imports
	gopkg.in/yaml.v2 tested by
	gopkg.in/yaml.v2.test imports
	gopkg.in/check.v1: k8s.io/api@v0.27.0 (replaced by ../../k8s.io/kubernetes/staging/src/k8s.io/api): reading ../../k8s.io/kubernetes/staging/src/k8s.io/api/go.mod: open /home/maha4472/go/src/k8s.io/kubernetes/staging/src/k8s.io/api/go.mod: no such file or directory
sigs.k8s.io/provider-aws-test-infra/test/e2e_node/remote/aws imports
	github.com/aws/aws-sdk-go/service/ec2 imports
	github.com/aws/aws-sdk-go/aws/awsutil imports
	github.com/jmespath/go-jmespath tested by
	github.com/jmespath/go-jmespath.test imports
	github.com/jmespath/go-jmespath/internal/testify/assert: k8s.io/api@v0.27.0 (replaced by ../../k8s.io/kubernetes/staging/src/k8s.io/api): reading ../../k8s.io/kubernetes/staging/src/k8s.io/api/go.mod: open /home/maha4472/go/src/k8s.io/kubernetes/staging/src/k8s.io/api/go.mod: no such file or directory
```