### PR TITLE
Adding configuration for arm64 based CI jobs

### DIFF
--- a/config/aws-instance-arm64.yaml
+++ b/config/aws-instance-arm64.yaml
@@ -1,0 +1,9 @@
+images:
+  al2023-6-1:
+    ssm_path: /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-arm64
+    instance_type: m6a.large
+    user_data_file: al2023-6.1.yaml
+  ubuntu-2204:
+    ssm_path: /aws/service/canonical/ubuntu/server/focal/stable/current/arm64/hvm/ebs-gp2/ami-id
+    instance_type: m6a.large
+    user_data_file: ubuntu2204.yaml


### PR DESCRIPTION
drop the eks version of images and keep the base ubuntu + al2023