### PR TITLE
Default to 4 hours of test timeout

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -104,7 +104,7 @@ delete_instances=${DELETE_INSTANCES:-"true"}
 instance_profile=${INSTANCE_PROFILE:-""}
 user_data_file=${USER_DATA_FILE:-""}
 test_suite=${TEST_SUITE:-"default"}
-if [[ -n "${TIMEOUT:-}" ]] ; then
+if [[ -n "${TIMEOUT:-"4h"}" ]] ; then
   timeout_arg="--test-timeout=${TIMEOUT}"
 fi
 


### PR DESCRIPTION
Currently this is 45 mins and that is not enough especially for serial tests:
https://github.com/kubernetes/kubernetes/blob/6dbb1c6cf074872ac39485b07b9bd3106654ae3a/test/e2e_node/remote/remote.go#L34