### PR TITLE
Add kubetest2 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,94 @@
+# Sync this file contents with https://github.com/kubernetes/kubernetes/blob/master/build/root/Makefile
+DBG_MAKEFILE ?=
+ifeq ($(DBG_MAKEFILE),1)
+    $(warning ***** starting Makefile for goal(s) "$(MAKECMDGOALS)")
+    $(warning ***** $(shell date))
+else
+    # If we're not debugging the Makefile, don't echo recipes.
+    MAKEFLAGS += -s
+endif
+
+
+# Old-skool build tools.
+#
+# Commonly used targets (see each target for more information):
+#   all: Build code.
+#   test: Run tests.
+#   clean: Clean up.
+
+# It's necessary to set this because some environments don't link sh -> bash.
+SHELL := /usr/bin/env bash -o errexit -o pipefail -o nounset
+
+# Define variables so `make --warn-undefined-variables` works.
+PRINT_HELP ?=
+
+# We don't need make's built-in rules.
+MAKEFLAGS += --no-builtin-rules
+.SUFFIXES:
+
+define TEST_E2E_NODE_HELP_INFO
+# Build and run node end-to-end tests.
+#
+# Args:
+#  FOCUS: Regexp that matches the tests to be run.  Defaults to "".
+#  SKIP: Regexp that matches the tests that needs to be skipped.
+#    Defaults to "\[Flaky\]|\[Slow\]|\[Serial\]".
+#  TEST_ARGS: A space-separated list of arguments to pass to node e2e test.
+#    Defaults to "".
+#  RUN_UNTIL_FAILURE: If true, pass --untilItFails to ginkgo so tests are run
+#    repeatedly until they fail.  Defaults to false.
+#  REMOTE: If true, run the tests on a remote host instance on GCE.  Defaults
+#    to false.
+#  ARTIFACTS: Local directory to scp test artifacts into from the remote hosts
+#    for REMOTE=true. Local directory to write juntil xml results into for REMOTE=false.
+#    Defaults to "/tmp/_artifacts/$$(date +%y%m%dT%H%M%S)".
+#  LIST_IMAGES: For REMOTE=true only. If true, don't run tests. Just output the
+#    list of available images for testing.  Defaults to false.
+#  TIMEOUT: For REMOTE=true only. How long (in golang duration format) to wait
+#    for ginkgo tests to complete. Defaults to 45m.
+#  PARALLELISM: The number of ginkgo nodes to run.  Defaults to 8.
+#  RUNTIME: Container runtime to use (eg. docker, remote).
+#    Defaults to "docker".
+#  CONTAINER_RUNTIME_ENDPOINT: remote container endpoint to connect to.
+#    Used when RUNTIME is set to "remote".
+#  IMAGE_SERVICE_ENDPOINT: remote image endpoint to connect to, to prepull images.
+#    Used when RUNTIME is set to "remote".
+#  IMAGE_CONFIG_FILE: path to a file containing image configuration.
+#  SYSTEM_SPEC_NAME: The name of the system spec to be used for validating the
+#    image in the node conformance test. The specs are located at
+#    test/e2e_node/system/specs/. For example, "SYSTEM_SPEC_NAME=gke" will use
+#    the spec at test/e2e_node/system/specs/gke.yaml. If unspecified, the
+#    default built-in spec (system.DefaultSpec) will be used.
+#  IMAGES: For REMOTE=true only.  Comma delimited list of images for creating
+#    remote hosts to run tests against.  Defaults to a recent image.
+#  HOSTS: For REMOTE=true only.  Comma delimited list of running gce hosts to
+#    run tests against.  Defaults to "".
+#  DELETE_INSTANCES: For REMOTE=true only.  Delete any instances created as
+#    part of this test run.  Defaults to false.
+#  PREEMPTIBLE_INSTANCES: For REMOTE=true only.  Mark created gce instances
+#    as preemptible.  Defaults to false.
+#  CLEANUP: For REMOTE=true only.  If false, do not stop processes or delete
+#    test files on remote hosts.  Defaults to true.
+#  IMAGE_PROJECT: For REMOTE=true only.  Project containing images provided to
+#    $$IMAGES.  Defaults to "kubernetes-node-e2e-images".
+#  INSTANCE_PREFIX: For REMOTE=true only.  Instances created from images will
+#    have the name "$${INSTANCE_PREFIX}-$${IMAGE_NAME}".  Defaults to "test".
+#  INSTANCE_METADATA: For REMOTE=true and running on GCE only.
+#  GUBERNATOR: For REMOTE=true only. Produce link to Gubernator to view logs.
+#    Defaults to false.
+#  TEST_SUITE: For REMOTE=true only. Test suite to use. Defaults to "default".
+#
+# Example:
+#   make test-e2e-node FOCUS=Kubelet SKIP=container
+#   make test-e2e-node REMOTE=true DELETE_INSTANCES=true
+#   make test-e2e-node TEST_ARGS='--kubelet-flags="--cgroups-per-qos=true"'
+# Build and run tests.
+endef
+.PHONY: test-e2e-node
+ifeq ($(PRINT_HELP),y)
+test-e2e-node:
+	@echo "$$TEST_E2E_NODE_HELP_INFO"
+else
+test-e2e-node:
+	hack/make-rules/test-e2e-node.sh
+endif

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -47,6 +47,7 @@ ssh_user=${SSH_USER:-"${USER}"}
 ssh_key=${SSH_KEY:-}
 ssh_options=${SSH_OPTIONS:-}
 kubelet_config_file=${KUBELET_CONFIG_FILE:-"test/e2e_node/jenkins/default-kubelet-config.yaml"}
+instance_type=${INSTANCE_TYPE:-}
 
 # Parse the flags to pass to ginkgo
 ginkgoflags="-timeout=24h"
@@ -152,7 +153,7 @@ go run test/e2e_node/runner/remote/run_remote.go  --mode="aws" --vmodule=*=4 \
   --delete-instances="${delete_instances}" --test_args="${test_args}" \
   --image-config-file="${image_config_file}" --system-spec-name="${system_spec_name}" \
   --runtime-config="${runtime_config}" --image-config-dir="${image_config_dir}" --region="${region}" \
-  --use-dockerized-build="${use_dockerized_build}" \
+  --use-dockerized-build="${use_dockerized_build}" --instance-type="${instance_type}" \
   --target-build-arch="${target_build_arch}" \
   --extra-envs="${extra_envs}" --kubelet-config-file="${kubelet_config_file}" --test-suite="${test_suite}" \
   "${timeout_arg}" \

--- a/test/e2e_node/remote/aws/aws_runner.go
+++ b/test/e2e_node/remote/aws/aws_runner.go
@@ -51,9 +51,9 @@ var region = flag.String("region", "", "AWS region that the hosts live in (aws)"
 var userDataFile = flag.String("user-data-file", "", "Path to user data to pass to created instances (aws)")
 var instanceProfile = flag.String("instance-profile", "", "The name of the instance profile to assign to the node (aws)")
 var instanceConnect = flag.Bool("ec2-instance-connect", true, "Use EC2 instance connect to generate a one time use key (aws)")
+var instanceType = flag.String("instance-type", "t3a.medium", "EC2 Instance type to use for test")
 var reuseInstances = flag.Bool("reuse-instances", false, "Reuse already running instance")
 
-const defaultAWSInstanceType = "t3a.medium"
 const amiIDTag = "Node-E2E-Test"
 
 type AWSRunner struct {
@@ -194,7 +194,7 @@ func (a *AWSRunner) prepareAWSImages() ([]internalAWSImage, error) {
 				imageDesc:       shortName,
 			}
 			if awsImage.instanceType == "" {
-				awsImage.instanceType = defaultAWSInstanceType
+				awsImage.instanceType = *instanceType
 			}
 			ret = append(ret, awsImage)
 		}
@@ -204,7 +204,7 @@ func (a *AWSRunner) prepareAWSImages() ([]internalAWSImage, error) {
 		for _, img := range a.cfg.Images {
 			ret = append(ret, internalAWSImage{
 				amiID:        img,
-				instanceType: defaultAWSInstanceType,
+				instanceType: *instanceType,
 			})
 		}
 	}


### PR DESCRIPTION
Merging https://github.com/kubernetes-sigs/kubetest2/pull/230 will allow us to use kubetest2 for both EC2 and GCE node e2e tests with simplified prowjob generator logic.

/cc @dims