### PR TITLE
install nfs-common package as a e2e node test is mounting an nfs server

### DIFF
--- a/config/ubuntu2204.yaml
+++ b/config/ubuntu2204.yaml
@@ -4,6 +4,10 @@ system_info:
   default_user:
     name: ec2-user
     groups: root
+package_upgrade: true
+package_update: true
+packages:
+    - nfs-common
 write_files:
   - path: /tmp/bootstrap/extra-fetches.yaml
     content: |


### PR DESCRIPTION
https://cs.k8s.io/?q=nfs&i=nope&files=.*mirror_pod_test.go&excludeFiles=&repos=

Errors looks like these:
```
Jun 29 17:35:33.680: INFO: At 2023-06-29 17:33:28 +0000 UTC - event for static-pod-nfs-test-pod03241026-a521-42ee-825d-2a6ece0586c0-i-0cff3de3e6ff915b7: {kubelet i-0cff3de3e6ff915b7} FailedMount: MountVolume.SetUp failed for volume "nfs-vol" : mount failed: exit status 32
Mounting command: mount
Mounting arguments: -t nfs 10.100.0.119:/exports /var/lib/kubelet/pods/aefc5e225fd23cb971c5db6b5d339959/volumes/kubernetes.io~nfs/nfs-vol
Output: mount: /var/lib/kubelet/pods/aefc5e225fd23cb971c5db6b5d339959/volumes/kubernetes.io~nfs/nfs-vol: bad option; for several filesystems (e.g. nfs, cifs) you might need a /sbin/mount.<type> helper program.
```