### PR TITLE
Build EKS AMI and then run node e2e tests using that new AMI

### DIFF
--- a/hack/bump-k8s.sh
+++ b/hack/bump-k8s.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 
+set -xeuo pipefail
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 KUBE_ROOT=${SCRIPTDIR}/../../../k8s.io/kubernetes/
 
+# shellcheck disable=SC2164
 pushd "${KUBE_ROOT}" >/dev/null
 git reset --hard HEAD && git clean -xdff
 git fetch --all
 git checkout master
+# shellcheck disable=SC2164
 popd >/dev/null
 
 git reset --hard HEAD && git clean -xdff

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -14,14 +14,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+set -xeuo pipefail
+
+pushd "$(go env GOPATH)/src/k8s.io/kubernetes" >/dev/null
+  KUBE_FULL_VERSION=$(hack/print-workspace-status.sh | grep gitVersion | awk '{print $2}')
+  KUBE_VERSION=$(echo $KUBE_FULL_VERSION | sed -E 's/v([0-9]+)\.([0-9]+)\.([0-9]+).*/v\1.\2.\3/')
+popd
+KUBE_DATE=$(date -u +'%Y-%m-%d')
+
 build_eks_ami=${BUILD_EKS_AMI:-"false"}
 if [[ ${build_eks_ami} != "false" ]]; then
-  ${ROOT}/hack/build-ami.sh
-  ami_id=$(jq -r ".builds[].artifact_id" $(go env GOPATH)/src/github.com/awslabs/amazon-eks-ami/manifest.json | cut -f 2 -d ':')
-  cat > ${ROOT}/config/aws-instance-eks.yaml <<EOF
+  ami_id=$(aws ec2 describe-images --region=us-east-1 --filters Name=name,Values=amazon-eks-node-${KUBE_VERSION}-v${KUBE_DATE}  --query 'Images[*].[ImageId]' --output text)
+  if [ -z "${ami_id}" ] ; then
+    TEST_INFRA_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+    ${TEST_INFRA_ROOT}/hack/build-ami.sh
+    ami_id=$(jq -r ".builds[].artifact_id" "$(go env GOPATH)/src/github.com/awslabs/amazon-eks-ami/manifest.json" | cut -f 2 -d ':')
+  else
+    echo "found existing ami : ${ami_id} skipping building a new AMI..."
+  fi
+  aws ec2 describe-images --region=us-east-1 --image-ids ${ami_id}
+  cat > ${TEST_INFRA_ROOT}/config/aws-instance-eks.yaml <<EOF
 images:
-  eks-ami-126:
+  eks-ami-daily:
     ami_id: ${ami_id}
     instance_type: m6a.large
     user_data_file: userdata.sh

--- a/hack/populate-s3.sh
+++ b/hack/populate-s3.sh
@@ -2,8 +2,8 @@
 
 set -xeuo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
-mkdir -p "${ROOT}/_output"
+TEST_INFRA_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+mkdir -p "${TEST_INFRA_ROOT}/_output"
 
 if [[ -z "$(which aarch64-linux-gnu-gcc)" || -z "$(which x86_64-linux-gnu-gcc)" ]]; then
   echo "Can't find aarch64-linux-gnu-gcc x86_64-linux-gnu-gcc or in PATH, please install and retry"
@@ -18,13 +18,14 @@ if [[ -z "$(which aarch64-linux-gnu-gcc)" || -z "$(which x86_64-linux-gnu-gcc)" 
   fi
 fi
 
-DATE=$(date -u +'%Y-%m-%d')
+KUBE_DATE=$(date -u +'%Y-%m-%d')
 
 # Generate kubernetes binaries
 pushd "$(go env GOPATH)/src/k8s.io/kubernetes" >/dev/null
 
-  VERSION=$(hack/print-workspace-status.sh | grep gitVersion | awk '{print $2}' | sed -E 's/v([0-9]+)\.([0-9]+)\.([0-9]+).*/v\1.\2.\3/')
-  BIN_DIR="${ROOT}/_output/${VERSION}/${DATE}/bin"
+  KUBE_FULL_VERSION=$(hack/print-workspace-status.sh | grep gitVersion | awk '{print $2}')
+  KUBE_VERSION=$(echo $KUBE_FULL_VERSION | sed -E 's/v([0-9]+)\.([0-9]+)\.([0-9]+).*/v\1.\2.\3/')
+  BIN_DIR="${TEST_INFRA_ROOT}/_output/${KUBE_VERSION}/${KUBE_DATE}/bin"
 
   make kubectl KUBE_BUILD_PLATFORMS="darwin/amd64" && \
     make kubectl KUBE_BUILD_PLATFORMS="darwin/arm64" && \
@@ -60,15 +61,15 @@ popd
 
 # Generate aws-iam-authenticator binaries
 pushd "$(go env GOPATH)/src/sigs.k8s.io/aws-iam-authenticator" >/dev/null
-  VERSION=$(git describe --tags `git rev-list --tags --max-count=1`)
-  echo ${VERSION/#v} > version.txt
+  AUTHENTICATOR_VERSION=$(git describe --tags `git rev-list --tags --max-count=1`)
+  echo ${AUTHENTICATOR_VERSION/#v} > version.txt
   make build-all-bins
 
-  cp "_output/bin/aws-iam-authenticator_${VERSION}_darwin_amd64" "${BIN_DIR}/darwin/amd64/aws-iam-authenticator"
-  #cp "${ROOT}/_output/local/bin/darwin/arm64/aws-iam-authenticator" "${BIN_DIR}/darwin/arm64/aws-iam-authenticator"
-  cp "_output/bin/aws-iam-authenticator_${VERSION}_linux_amd64" "${BIN_DIR}/linux/amd64/aws-iam-authenticator"
-  cp "_output/bin/aws-iam-authenticator_${VERSION}_linux_arm64" "${BIN_DIR}/linux/arm64/aws-iam-authenticator"
-  cp "_output/bin/aws-iam-authenticator_${VERSION}_windows_amd64.exe" "${BIN_DIR}/windows/amd64/aws-iam-authenticator.exe"
+  cp "_output/bin/aws-iam-authenticator_${AUTHENTICATOR_VERSION}_darwin_amd64" "${BIN_DIR}/darwin/amd64/aws-iam-authenticator"
+  #cp "${TEST_INFRA_ROOT}/_output/local/bin/darwin/arm64/aws-iam-authenticator" "${BIN_DIR}/darwin/arm64/aws-iam-authenticator"
+  cp "_output/bin/aws-iam-authenticator_${AUTHENTICATOR_VERSION}_linux_amd64" "${BIN_DIR}/linux/amd64/aws-iam-authenticator"
+  cp "_output/bin/aws-iam-authenticator_${AUTHENTICATOR_VERSION}_linux_arm64" "${BIN_DIR}/linux/arm64/aws-iam-authenticator"
+  cp "_output/bin/aws-iam-authenticator_${AUTHENTICATOR_VERSION}_windows_amd64.exe" "${BIN_DIR}/windows/amd64/aws-iam-authenticator.exe"
 
 popd
 


### PR DESCRIPTION
Threading it all together
- build ami straight from main branch of amazon-eks-ami
- but using k8s binaries we push to our own s3 bucket
- avoid rebuilding the AMI more than once a day
- ensure scripts fail fast
- avoid tripping over the variable names across scripts