### PR TITLE
Run e2e tests without specifying an image config file

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -136,8 +136,9 @@ if [[ "${test_args}" != *"server-start-timeout"* ]]; then
 fi
 
 hosts=${HOSTS:-""}
-image_config_file=${IMAGE_CONFIG_FILE:-"aws-instance.yaml"}
-image_config_dir=${IMAGE_CONFIG_DIR:-"config"}
+images=${IMAGES:-""}
+image_config_file=${IMAGE_CONFIG_FILE:-""}
+image_config_dir=${IMAGE_CONFIG_DIR:-""}
 use_dockerized_build=${USE_DOCKERIZED_BUILD:-"false"}
 target_build_arch=${TARGET_BUILD_ARCH:-""}
 runtime_config=${RUNTIME_CONFIG:-""}
@@ -174,6 +175,9 @@ echo "Region: ${region}"
 if [[ -n ${hosts} ]]; then
   echo "Hosts: ${hosts}"
 fi
+if [[ -n ${images} ]]; then
+  echo "Images: ${images}"
+fi
 echo "SSH User: ${ssh_user}"
 if [[ -n ${ssh_key} ]]; then
   echo "SSH Key: ${ssh_key}"
@@ -182,7 +186,12 @@ if [[ -n ${ssh_options} ]]; then
   echo "SSH Options: ${ssh_options}"
 fi
 echo "Ginkgo Flags: ${ginkgoflags}"
-echo "Image Config File: ${image_config_dir}/${image_config_file}"
+if [[ -n ${image_config_file} ]]; then
+  echo "Image Config File: ${image_config_dir}/${image_config_file}"
+fi
+if [[ -n ${instance_type} ]]; then
+  echo "Instance Type: ${instance_type}"
+fi
 echo "Kubelet Config File: ${kubelet_config_file}"
 echo "Kubernetes directory: ${KUBE_ROOT}"
 
@@ -192,7 +201,7 @@ go run test/e2e_node/runner/remote/run_remote.go  --mode="aws" --vmodule=*=4 \
   --instance-profile="${instance_profile}" --hosts="${hosts}" --cleanup="${cleanup}" \
   --results-dir="${artifacts}" --ginkgo-flags="${ginkgoflags}" --runtime-config="${runtime_config}" \
   --instance-name-prefix="${instance_prefix}" --user-data-file="${user_data_file}" \
-  --delete-instances="${delete_instances}" --test_args="${test_args}" \
+  --delete-instances="${delete_instances}" --test_args="${test_args}" --images="${images}" \
   --image-config-file="${image_config_file}" --system-spec-name="${system_spec_name}" \
   --runtime-config="${runtime_config}" --image-config-dir="${image_config_dir}" --region="${region}" \
   --use-dockerized-build="${use_dockerized_build}" --instance-type="${instance_type}" \


### PR DESCRIPTION
This change is designed to work with kubetest2 changes.

Right now, an image config file that looks like this is required:

```yaml
images:
  al2023-6-1:
    ssm_path: /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-arm64
    instance_type: m6g.large
    user_data_file: al2023-6.1.yaml
  ubuntu-2204:
    ssm_path: /aws/service/canonical/ubuntu/server/jammy/stable/current/arm64/hvm/ebs-gp2/ami-id
    instance_type: m6g.large
    user_data_file: ubuntu2204.yaml
```

This is quite burdensome and I'm proposing the following changes:

Pass everything required as flags to kubetest2 so the generator I'm writing can work easily. kops configures all their various mutations by various flags being passed to kubetest2.

For example, to run ubuntu2204 tests, all I would do is pass two different for values for the `instance-type` and `images` arguments and use a common `user-data-file`


```# instance type in intentionally correct to reduce short output
ubuntu@dev:~/go/src/k8s.io/kubernetes$ kubetest2 noop --test node -- --provider=aws --images=ami-03a4363a7d864a093 --instance-type=e2-standard-2 --repo-root=../../sigs.k8s.io/provider-aws-test-infra/ --user-data-file=../../sigs.k8s.io/provider-aws-test-infra/config/ubuntu2204.yaml
I0717 20:14:22.586716  111665 app.go:61] The files in RunDir shall not be part of Artifacts
I0717 20:14:22.586972  111665 app.go:62] pass rundir-in-artifacts flag True for RunDir to be part of Artifacts
I0717 20:14:22.587027  111665 app.go:64] RunDir for this run: "/home/ubuntu/go/src/k8s.io/kubernetes/_rundir/bfbe852b-e08a-4f0e-844c-bea40a2eabe8"
I0717 20:14:22.588245  111665 app.go:130] ID for this run: "bfbe852b-e08a-4f0e-844c-bea40a2eabe8"
Test artifacts will be written to /home/ubuntu/go/src/k8s.io/kubernetes/_artifacts
Running tests remotely using
Account: 855606814420
Region: us-east-1
Images: ami-03a4363a7d864a093
SSH User: ubuntu
Ginkgo Flags: -timeout=24h -nodes=8  -skip="\[Flaky\]|\[Slow\]|\[Serial\]"
Instance Type: e2-standard-2
Kubelet Config File: test/e2e_node/jenkins/default-kubelet-config.yaml
Kubernetes directory: /home/ubuntu/go/src/k8s.io/kubernetes
Will use ginkgo flags as: -timeout=24h -nodes=8  -skip="\[Flaky\]|\[Slow\]|\[Serial\]"  --no-color -vI0717 20:14:29.272600  111768 remote.go:72] Building archive...
I0717 20:14:29.273069  111768 build.go:45] Building k8s binaries...
go version go1.20.6 linux/amd64
+++ [0717 20:14:29] Setting GOMAXPROCS: 4
+++ [0717 20:14:29] Building go targets for linux/amd64
    k8s.io/kubernetes/cmd/kubelet (non-static)
    k8s.io/kubernetes/test/e2e_node/e2e_node.test (test)
    github.com/onsi/ginkgo/v2/ginkgo (non-static)
    k8s.io/kubernetes/cluster/gce/gci/mounter (non-static)
    k8s.io/kubernetes/test/e2e_node/plugins/gcp-credential-provider (non-static)
I0717 20:14:48.577169  111768 node_e2e.go:65] Copying binaries from /home/ubuntu/go/src/k8s.io/kubernetes/_output/local/go/bin/kubelet
I0717 20:14:48.672399  111768 node_e2e.go:65] Copying binaries from /home/ubuntu/go/src/k8s.io/kubernetes/_output/local/go/bin/e2e_node.test
I0717 20:14:48.800498  111768 node_e2e.go:65] Copying binaries from /home/ubuntu/go/src/k8s.io/kubernetes/_output/local/go/bin/ginkgo
I0717 20:14:48.810820  111768 node_e2e.go:65] Copying binaries from /home/ubuntu/go/src/k8s.io/kubernetes/_output/local/go/bin/mounter
I0717 20:14:48.814150  111768 node_e2e.go:65] Copying binaries from /home/ubuntu/go/src/k8s.io/kubernetes/_output/local/go/bin/gcp-credential-provider
Initializing e2e tests using image  / ami-03a4363a7d864a093.

>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
>                              START TEST                                >
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
Start Test Suite on Host

Failure Finished Test Suite on Host . Refer to artifacts directory for ginkgo log for this host.
unable to create EC2 instance for image ami-03a4363a7d864a093, creating instance, InvalidParameterValue: Invalid value 'e2-standard-2' for InstanceType.
	status code: 400, request id: 4fc21d51-a51b-4557-b0d4-7d662aff80cb
<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
<                              FINISH TEST                               <
<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<

Failure: 1 errors encountered.
exit status 1
>> go run exited with 1 at Mon Jul 17 20:15:03 UTC 2023

test-e2e-node.sh: FAIL
make: *** [Makefile:93: test-e2e-node] Error 1
F0717 20:15:03.743609  111677 node.go:282] failed to run ginkgo tester: exit status 2
Error: exit status 255
```


/cc @dims 
