### PR TITLE
Trying to fix update dependencies action

### DIFF
--- a/hack/bump-k8s.sh
+++ b/hack/bump-k8s.sh
@@ -14,6 +14,8 @@ git checkout master
 popd >/dev/null
 
 git reset --hard HEAD && git clean -xdff
+
+export GOPROXY=direct
 go get k8s.io/kubernetes@HEAD
 go mod tidy
 go mod vendor


### PR DESCRIPTION
current failure before this PR was:

```
+ go get k8s.io/kubernetes@HEAD
go: k8s.io/kubernetes@HEAD: invalid version: reading https://proxy.golang.org/k8s.io/kubernetes/@v/%21h%21e%21a%21d.info: 404 Not Found
	server response: not found: fetch timed out
```