### PR TITLE
Drop the dirty suffix in version number

### DIFF
--- a/kubetest2-ec2/pkg/deployer/utils/source.go
+++ b/kubetest2-ec2/pkg/deployer/utils/source.go
@@ -43,7 +43,7 @@ func SourceVersion(kubeRoot string) (string, error) {
 		}
 		if parts[0] == "gitVersion" {
 			version = parts[1]
-			return version, nil
+			return strings.TrimSuffix(version, "-dirty"), nil
 		}
 	}
 	if version == "" {


### PR DESCRIPTION
some of the operations may end up with `./hack/print-workspace-status.sh` returning version with `-dirty` in it, indicating that an extra modification to one of the files is present or the git workspace is not pristine enough (extra file?). just ignore those for now. (see example below)

```
[40915:40912 - 0:2038] 09:02:34 [davanum@c889f3bd53ed:o +1] ~/go/src/k8s.io/kubernetes
$ touch a.txt
[40915:40912 - 0:2039] 03:27:00 [davanum@c889f3bd53ed:o +1] ~/go/src/k8s.io/kubernetes
$ hack/print-workspace-status.sh
STABLE_BUILD_GIT_COMMIT f4041204c0029374be6949164c6f184e27408f7e
STABLE_BUILD_SCM_STATUS dirty
STABLE_BUILD_SCM_REVISION v1.29.0-alpha.0.40+f4041204c00293-dirty
STABLE_BUILD_MAJOR_VERSION 1
STABLE_BUILD_MINOR_VERSION 29+
STABLE_DOCKER_TAG v1.29.0-alpha.0.40_f4041204c00293-dirty
STABLE_DOCKER_REGISTRY registry.k8s.io
STABLE_DOCKER_PUSH_REGISTRY staging-k8s.gcr.io
gitCommit f4041204c0029374be6949164c6f184e27408f7e
gitTreeState dirty
gitVersion v1.29.0-alpha.0.40+f4041204c00293-dirty
gitMajor 1
gitMinor 29+
buildDate 2023-08-08T19:27:05Z
```