### PR TITLE
use the usual directory for CNI as AWS VPC CNI does not like alternate directories

### DIFF
--- a/config/configure.sh
+++ b/config/configure.sh
@@ -193,7 +193,7 @@ mkdir -p $(dirname ${config_path})
 
 # Download and configure CNI
 cni_template_path="${CONTAINERD_HOME}/opt/containerd/cluster/gce/cni.template"
-cni_bin_dir="${CONTAINERD_HOME}/opt/cni/bin"
+cni_bin_dir="/opt/cni/bin"
 
 CNI_VERSION=v1.2.0 &&\
 mkdir -p ${cni_bin_dir} &&\


### PR DESCRIPTION
```
  Warning  FailedCreatePodSandBox  10m                 kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "715301634ac099a9643293f42cffa758b4faa9c16600bc800be1d626f9ae610e": plugin type="aws-cni" name="aws-cni" failed (add): failed to find plugin "aws-cni" in path [/home/containerd/opt/cni/bin]
```