### PR TITLE
Switch back to aws vpc cni - Revert systemd-udev change (MACAddressPolicy)  that disables networking from pods

### DIFF
--- a/kubetest2-ec2/config/ubuntu2204.yaml
+++ b/kubetest2-ec2/config/ubuntu2204.yaml
@@ -199,7 +199,9 @@ runcmd:
   - iptables -F && iptables -X  && iptables -t nat -F  && iptables -t nat -X && iptables -t mangle -F  && iptables -t mangle -X  && iptables -P INPUT ACCEPT  && iptables -P FORWARD ACCEPT && iptables -P OUTPUT ACCEPT
   # Ensure instance-id resolves to the ip address of the host
   - "echo \"$(dig $(curl -s -f -m 1 http://169.254.169.254/latest/meta-data/instance-id/).ec2.internal +short) $(curl -s -f -m 1 http://169.254.169.254/latest/meta-data/instance-id/)\" | sudo tee -a /etc/hosts"
-  - "sudo sed -i \"s/^#ReadEtcHosts/ReadEtcHosts/\" /etc/systemd/resolved.conf"
+  - "sed -i \"s/^#ReadEtcHosts/ReadEtcHosts/\" /etc/systemd/resolved.conf"
+  # Fix issues with no networking from pods
+  - "sed -i \"s/^MACAddressPolicy=.*/MACAddressPolicy=none/\" /usr/lib/systemd/network/99-default.link"
   - systemctl restart systemd-resolved
   - rm /usr/lib/systemd/logind.conf.d/unattended-upgrades-logind-maxdelay.conf
   - systemctl restart systemd-logind

--- a/kubetest2-ec2/config/ubuntu2204.yaml
+++ b/kubetest2-ec2/config/ubuntu2204.yaml
@@ -185,15 +185,7 @@ write_files:
       set -xeu
       KUBEADM_CONTROL_PLANE={{KUBEADM_CONTROL_PLANE}}
       if [[ ${KUBEADM_CONTROL_PLANE} == true ]]; then
-        if [ "$(uname -m)" = "arm64" ] || [ "$(uname -m)" = "aarch64" ]; then
-          ARCH=arm64
-        else
-          ARCH=amd64
-        fi
-        curl -sSL --retry 5 https://github.com/cilium/cilium-cli/releases/latest/download/cilium-linux-$ARCH.tar.gz | tar -xz -C /usr/local/bin
-        export KUBECONFIG=/etc/kubernetes/admin.conf
-        cilium install --version 1.14.0
-        cilium status --wait
+        kubectl --kubeconfig /etc/kubernetes/admin.conf create -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.13.4/config/master/aws-k8s-cni.yaml
       fi
   - path: /home/containerd/configure.sh
     encoding: gzip+base64
@@ -204,7 +196,7 @@ runcmd:
   - ufw disable || echo "ufw not installed"
   - systemctl stop apparmor
   - systemctl disable apparmor
-  - iptables -F && iptables -t nat -F && iptables -t mangle -F && iptables -X
+  - iptables -F && iptables -X  && iptables -t nat -F  && iptables -t nat -X && iptables -t mangle -F  && iptables -t mangle -X  && iptables -P INPUT ACCEPT  && iptables -P FORWARD ACCEPT && iptables -P OUTPUT ACCEPT
   # Ensure instance-id resolves to the ip address of the host
   - "echo \"$(dig $(curl -s -f -m 1 http://169.254.169.254/latest/meta-data/instance-id/).ec2.internal +short) $(curl -s -f -m 1 http://169.254.169.254/latest/meta-data/instance-id/)\" | sudo tee -a /etc/hosts"
   - "sudo sed -i \"s/^#ReadEtcHosts/ReadEtcHosts/\" /etc/systemd/resolved.conf"


### PR DESCRIPTION
xref:
- https://github.com/aws/amazon-vpc-cni-k8s/pull/2161/commits/ceacdb9ee02f6945070665770165b138a1125ae7
- original issue from kops folks : https://github.com/aws/amazon-vpc-cni-k8s/issues/2103
- Looks like https://github.com/aws/amazon-vpc-cni-k8s/pull/2118 still has to land

thanks @tzneal @jdn5126 @jayanthvn for debugging and tips!

```
systemd-udev - Linux distributions that install the systemd-udev package create /usr/lib/systemd/network/99-default.link with Link.MACAddressPolicy set to persistent. This policy may cause the MAC address assigned to the host veth interface for a pod to change after the interface is moved to the host network namespace. The CNI plugin installs a static ARP binding for the default gateway in the pod network namespace pointing to the host veth MAC, so the MAC changing leads to pod connectivity issues. The workaround for this issue is to set MACAddressPolicy=none, as shown here. This issue is known to affect Ubuntu 22.04+, and long-term solutions are being evaluated.
```

fixes problem where there is no networking from pods! first symptom is that coredns crash loops as it can't talk to apiserver
