### PR TITLE
Instance types are way too small

### DIFF
--- a/kubetest2-ec2/pkg/deployer/deployer.go
+++ b/kubetest2-ec2/pkg/deployer/deployer.go
@@ -42,6 +42,9 @@ import (
 // Name is the name of the deployer
 const Name = "ec2"
 
+const defaultAMD64InstanceType = "r5d.4xlarge"
+const defaultARM64InstanceTYpe = "r7g.4xlarge"
+
 var GitTag string
 
 // New implements deployer.New for ec2
@@ -70,7 +73,7 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 			},
 		},
 		Ec2InstanceConnect: true,
-		InstanceType:       "t3a.medium",
+		InstanceType:       defaultAMD64InstanceType,
 		SSHUser:            user,
 		SSHEnv:             "aws",
 		Region:             "us-east-1",

--- a/kubetest2-ec2/pkg/deployer/up.go
+++ b/kubetest2-ec2/pkg/deployer/up.go
@@ -220,8 +220,8 @@ func (a *AWSRunner) Validate() error {
 
 		// Looks like we need an arm64 image and the default instance type is amd64, so
 		// pick an equivalent image to t3a.medium which is t4g.medium.
-		if a.deployer.InstanceType == "t3a.medium" && arch == "arm64" {
-			a.deployer.InstanceType = "t4g.medium"
+		if a.deployer.InstanceType == defaultAMD64InstanceType && arch == "arm64" {
+			a.deployer.InstanceType = defaultARM64InstanceTYpe
 		}
 	}
 


### PR DESCRIPTION
We need larger instance types for running more pods. Let's not constrict ourselves right now. 

Also more pods, needs more ENI(s), especially for AWS VPC CNI, or we run into `ContainerCreating` issue where pods are stuck. Context:
- https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/troubleshooting.md
- https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/eni-and-ip-target.md
- https://webera.blog/eks-aws-default-vpc-cni-tuning-for-small-networks-a81cbfc48549
- https://github.com/aws/aws-eks-best-practices/blob/master/content/networking/vpc-cni/index.md
- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html