### PR TITLE
experiment with static linking of kubelet

### DIFF
--- a/hack/populate-s3.sh
+++ b/hack/populate-s3.sh
@@ -29,9 +29,9 @@ pushd "$(go env GOPATH)/src/k8s.io/kubernetes" >/dev/null
 
   make kubectl KUBE_BUILD_PLATFORMS="darwin/amd64" && \
     make kubectl KUBE_BUILD_PLATFORMS="darwin/arm64" && \
-    make kubectl kubelet kube-proxy KUBE_BUILD_PLATFORMS="linux/arm64" && \
-    make kubectl kubelet kube-proxy KUBE_BUILD_PLATFORMS="linux/amd64" && \
-    make kubectl kubelet kube-proxy KUBE_BUILD_PLATFORMS="windows/amd64"
+    make kubectl kubelet kube-proxy KUBE_STATIC_OVERRIDES="kubelet" KUBE_BUILD_PLATFORMS="linux/arm64" && \
+    make kubectl kubelet kube-proxy KUBE_STATIC_OVERRIDES="kubelet" KUBE_BUILD_PLATFORMS="linux/amd64" && \
+    make kubectl kubelet kube-proxy KUBE_STATIC_OVERRIDES="kubelet" KUBE_BUILD_PLATFORMS="windows/amd64"
 
   mkdir -p "${BIN_DIR}/darwin/amd64"
   cp "_output/local/bin/darwin/amd64/kubectl" "${BIN_DIR}/darwin/amd64"

--- a/kubetest2-ec2/pkg/deployer/build/make.go
+++ b/kubetest2-ec2/pkg/deployer/build/make.go
@@ -58,7 +58,8 @@ func (m *MakeBuilder) buildQuickRelease() (string, error) {
 		return "", fmt.Errorf("failed to get version: %v", err)
 	}
 	cmd := exec.Command("make", target,
-		fmt.Sprintf("KUBE_BUILD_PLATFORMS=%s", m.TargetBuildArch))
+		fmt.Sprintf("KUBE_BUILD_PLATFORMS=%s", m.TargetBuildArch),
+		"KUBE_STATIC_OVERRIDES=kubelet")
 	cmd.SetDir(m.RepoRoot)
 	setSourceDateEpoch(m.RepoRoot, cmd)
 	exec.InheritOutput(cmd)


### PR DESCRIPTION
related to https://github.com/kubernetes/kubernetes/pull/121597

snippet from [logs](https://storage.googleapis.com/kubernetes-jenkins/logs/ci-cgroupv1-containerd-node-arm64-e2e-ec2-eks/1718955351631466496/build-log.txt)
```
2023-10-30T12:00:40Z:     amazon-ebs: kubelet: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by kubelet)
2023-10-30T12:00:40Z:     amazon-ebs: kubelet: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by kubelet)
```

WARNING! https://github.com/kubernetes/kubernetes/pull/114225#issuecomment-1349503950