### PR TITLE
check for ami image again just before make k8s

### DIFF
--- a/hack/build-ami.sh
+++ b/hack/build-ami.sh
@@ -52,6 +52,11 @@ pushd "$(go env GOPATH)/src/github.com/awslabs/amazon-eks-ami" >/dev/null
     sed -i 's/x86_64/arm64/' ${PACKER_TEMPLATE_FILE}
   fi
   make k8s kubernetes_version=${KUBE_VERSION} kubernetes_build_date=${KUBE_DATE} \
-    pull_cni_from_github=true arch=${BUILD_EKS_AMI_ARCH:-"x86_64"}
+    pull_cni_from_github=true arch=${BUILD_EKS_AMI_ARCH:-"x86_64"} || true
+  ami_id=$(aws ec2 describe-images --region=us-east-1 --filters Name=name,Values="$AMI_NAME" --query 'Images[*].[ImageId]' --output text)
+  if [ -z "${ami_id}" ] ; then
+    echo "unable to build ${AMI_NAME}, please see packer logs above..."
+    exit 1
+  fi
 # shellcheck disable=SC2164
 popd

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -37,12 +37,15 @@ if [[ ${build_eks_ami} != "false" ]]; then
   fi
   user_data_file="userdata.sh"
   if [[ ${BUILD_EKS_AMI_OS:-""} == "al2023" ]]; then
+    AMI_NAME="amazon-eks-${build_eks_arch}node-al2023-${KUBE_MINOR_VERSION}-v${TODAYS_DATE}"
     user_data_file="userdata-al2023.sh"
-    ami_id=$(aws ec2 describe-images --region=us-east-1 --filters Name=name,Values=amazon-eks-${build_eks_arch}node-al2023-${KUBE_MINOR_VERSION}-v${TODAYS_DATE}  --query 'Images[*].[ImageId]' --output text)
+    ami_id=$(aws ec2 describe-images --region=us-east-1 --filters Name=name,Values="$AMI_NAME"  --query 'Images[*].[ImageId]' --output text)
   else
-    ami_id=$(aws ec2 describe-images --region=us-east-1 --filters Name=name,Values=amazon-eks-${build_eks_arch}node-${KUBE_MINOR_VERSION}-v${TODAYS_DATE}  --query 'Images[*].[ImageId]' --output text)
+    AMI_NAME="amazon-eks-${build_eks_arch}node-${KUBE_MINOR_VERSION}-v${TODAYS_DATE}"
+    ami_id=$(aws ec2 describe-images --region=us-east-1 --filters Name=name,Values="$AMI_NAME"  --query 'Images[*].[ImageId]' --output text)
   fi
   if [ -z "${ami_id}" ] ; then
+    export AMI_NAME
     ${TEST_INFRA_ROOT}/hack/build-ami.sh
     ami_id=$(jq -r ".builds[].artifact_id" "$(go env GOPATH)/src/github.com/awslabs/amazon-eks-ami/manifest.json" | cut -f 2 -d ':')
   else


### PR DESCRIPTION
We may be running CI jobs in parallel and a couple of them may end up trying to build the same image at the same time and trip over each other. So even if `make k8s` fails, check if the ami is present because that's what we need to continue.