### PR TITLE
tolerate -E vs --setenv for systemd-run command

### DIFF
--- a/config/aws-instance-eks.yaml
+++ b/config/aws-instance-eks.yaml
@@ -1,9 +1,9 @@
 images:
-  eks-ami-126:
-    ssm_path: /aws/service/eks/optimized-ami/1.26/amazon-linux-2/recommended/image_id
-    instance_type: m6a.large
-    user_data_file: userdata.sh
   eks-ami-127:
     ssm_path: /aws/service/eks/optimized-ami/1.27/amazon-linux-2/recommended/image_id
+    instance_type: m6a.large
+    user_data_file: userdata.sh
+  eks-ami-128:
+    ssm_path: /aws/service/eks/optimized-ami/1.28/amazon-linux-2/recommended/image_id
     instance_type: m6a.large
     user_data_file: userdata.sh

--- a/config/userdata.sh
+++ b/config/userdata.sh
@@ -47,7 +47,9 @@ import subprocess
 
 actual_args = ["systemd-run.real"]
 for arg in sys.argv[1:]:
- if arg.startswith('StandardError'):
+ if arg.startswith('-E'):
+  actual_args.append(arg.replace("-E","--setenv"))
+ elif arg.startswith('StandardError'):
   # remove the -p
   actual_args.pop()
  else:

--- a/test/e2e_node/remote/aws/aws_runner.go
+++ b/test/e2e_node/remote/aws/aws_runner.go
@@ -306,7 +306,7 @@ func (a *AWSRunner) getAWSInstance(img internalAWSImage) (*awsInstance, error) {
 
 	instanceRunning := false
 	createdSSHKey := false
-	for i := 0; i < 10 && !instanceRunning; i++ {
+	for i := 0; i < 50 && !instanceRunning; i++ {
 		if i > 0 {
 			time.Sleep(time.Second * 20)
 		}


### PR DESCRIPTION
the version of systemd-run in EKS images do not support `-E` added here:
https://github.com/kubernetes/kubernetes/commit/ad7b9b56f5b2eabd6fa2de0446bcf8f858722e4d#diff-39ac8bcd746449ace559f6d09bd16a43bf207323181481899f906adb55b03c6fR253

- Also bump time we wait for things to come up
- Bump to newer EKS images