### PR TITLE
Add support to run al2 worker nodes

### DIFF
--- a/kubetest2-ec2/config/al2.sh
+++ b/kubetest2-ec2/config/al2.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -o xtrace
+set -xeuo pipefail
+
+if [ "$(uname -m)" = "arm64" ] || [ "$(uname -m)" = "aarch64" ]; then
+  ARCH=arm64
+else
+  ARCH=amd64
+fi
+
+mkdir -p /etc/kubernetes/
+cat << EOF > /etc/kubernetes/kubeadm-join.yaml
+apiVersion: kubeadm.k8s.io/v1beta3
+kind: JoinConfiguration
+discovery:
+  bootstrapToken:
+    apiServerEndpoint: {{KUBEADM_CONTROL_PLANE_IP}}:6443
+    token: {{KUBEADM_TOKEN}}
+    unsafeSkipCAVerification: true
+nodeRegistration:
+  criSocket: unix:///run/containerd/containerd.sock
+  name: {{HOSTNAME_OVERRIDE}}
+  kubeletExtraArgs:
+    cloud-provider: {{EXTERNAL_CLOUD_PROVIDER}}
+    provider-id: {{PROVIDER_ID}}
+    node-ip: {{NODE_IP}}
+    hostname-override: {{HOSTNAME_OVERRIDE}}
+    image-credential-provider-bin-dir: /etc/eks/image-credential-provider/
+    image-credential-provider-config: /etc/eks/image-credential-provider/config.json
+    resolv-conf: /etc/resolv.conf
+EOF
+
+META_URL=http://169.254.169.254/latest/meta-data
+AVAILABILITY_ZONE=$(curl -s $META_URL/placement/availability-zone)
+INSTANCE_ID=$(curl -s $META_URL/instance-id)
+PROVIDER_ID="aws:///$AVAILABILITY_ZONE/$INSTANCE_ID"
+PRIVATE_DNS_NAME=$(curl -s $META_URL/hostname)
+NODE_IP=$(curl -s $META_URL/local-ipv4)
+
+sed -i "s|{{PROVIDER_ID}}|$PROVIDER_ID|g" /etc/kubernetes/kubeadm-join.yaml
+sed -i "s|{{HOSTNAME_OVERRIDE}}|$PRIVATE_DNS_NAME|g" /etc/kubernetes/kubeadm-join.yaml
+sed -i "s|{{NODE_IP}}|$NODE_IP|g" /etc/kubernetes/kubeadm-join.yaml
+
+VERSION="v1.28.0"
+curl -sSL --fail --retry 5 https://storage.googleapis.com/k8s-artifacts-cri-tools/release/$VERSION/crictl-$VERSION-linux-$ARCH.tar.gz | sudo tar -xvzf - -C /usr/local/bin
+
+RELEASE_VERSION="v0.16.4"
+curl -sSL "https://raw.githubusercontent.com/kubernetes/release/${RELEASE_VERSION}/cmd/krel/templates/latest/kubelet/kubelet.service" | sed "s:/usr/bin:/bin:g" | sudo tee /etc/systemd/system/kubelet.service
+sudo mkdir -p /etc/systemd/system/kubelet.service.d
+curl -sSL "https://raw.githubusercontent.com/kubernetes/release/${RELEASE_VERSION}/cmd/krel/templates/latest/kubeadm/10-kubeadm.conf" | sed "s:/usr/bin:/bin:g" | sudo tee /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+systemctl enable --now kubelet
+
+# shellcheck disable=SC2050
+if [[ "{{STAGING_BUCKET}}" =~ ^s3.*  ]]; then
+  aws s3 cp "{{STAGING_BUCKET}}/{{STAGING_VERSION}}/kubernetes-server-linux-$ARCH.tar.gz" "kubernetes-server-linux-$ARCH.tar.gz"
+elif [[ "{{STAGING_BUCKET}}" =~ ^https.*  ]]; then
+  curl -sSLo kubernetes-server-linux-$ARCH.tar.gz --fail --retry 5 "{{STAGING_BUCKET}}/{{STAGING_VERSION}}/kubernetes-server-linux-$ARCH.tar.gz"
+else
+  aws s3 cp "s3://{{STAGING_BUCKET}}/{{STAGING_VERSION}}/kubernetes-server-linux-$ARCH.tar.gz" "kubernetes-server-linux-$ARCH.tar.gz"
+fi
+
+tar -xvzf kubernetes-server-linux-$ARCH.tar.gz
+cp ./kubernetes/server/bin/* /usr/local/bin/
+
+# shellcheck disable=SC2038
+find . -name "*.tar" -print | xargs -L 1 ctr -n k8s.io images import
+# shellcheck disable=SC2016
+ctr -n k8s.io images ls -q | grep -e $ARCH | xargs -L 1 -I '{}' /bin/bash -c 'ctr -n k8s.io images tag "{}" "$(echo "{}" | sed s/-'$ARCH':/:/)"'
+
+# shellcheck disable=SC2155
+export PATH=$PATH:/usr/local/bin
+
+kubeadm join \
+   --v 10 \
+   --config /etc/kubernetes/kubeadm-join.yaml

--- a/kubetest2-ec2/config/run-kubeadm.sh
+++ b/kubetest2-ec2/config/run-kubeadm.sh
@@ -65,6 +65,12 @@ if [[ ${KUBEADM_CONTROL_PLANE} == true ]]; then
    --v 10 \
    --ignore-preflight-errors=ImagePull \
    --config /etc/kubernetes/kubeadm-init.yaml
+
+  kubeadm init phase upload-certs \
+    --v 10 \
+    --upload-certs \
+    --skip-certificate-key-print \
+    --certificate-key "{{KUBEADM_CERTIFICATE_KEY}}"
 else
   sed -i "s|{{BOOTSTRAP_TOKEN}}|{{KUBEADM_TOKEN}}|g" /etc/kubernetes/kubeadm-join.yaml
   sed -i "s|{{KUBEADM_CONTROL_PLANE_IP}}|$KUBEADM_CONTROL_PLANE_IP|g" /etc/kubernetes/kubeadm-join.yaml

--- a/kubetest2-ec2/pkg/deployer/deployer.go
+++ b/kubetest2-ec2/pkg/deployer/deployer.go
@@ -109,7 +109,8 @@ type deployer struct {
 	ExternalCloudProviderImage string `desc:"repository:tag for the external cloud provider image"`
 
 	Region             string `desc:"AWS region that the hosts live in (aws)"`
-	UserDataFile       string `desc:"Path to user data to pass to created instances (aws)"`
+	UserDataFile       string `flag:"user-data-file" desc:"Path to user data to pass to control plane instances (aws)"`
+	WorkerUserDataFile string `flag:"worker-user-data-file" desc:"Path to user data to pass to worker node instances (aws)"`
 	KubeadmInitFile    string `desc:"custom kubeadm-init config file (aws)"`
 	KubeadmJoinFile    string `desc:"custom kubeadm-join config file (aws)"`
 	InstanceProfile    string `desc:"The name of the instance profile to assign to the node (aws)"`
@@ -117,6 +118,7 @@ type deployer struct {
 	Ec2InstanceConnect bool   `desc:"Use EC2 instance connect to generate a one time use key (aws)"`
 	InstanceType       string `desc:"EC2 Instance type to use for test"`
 	Image              string `flag:"image" desc:"Ubuntu image to use for test"`
+	WorkerImage        string `flag:"worker-image" desc:"Worker image to use for test"`
 	SSHUser            string `flag:"ssh-user" desc:"The SSH user to use for SSH access to instances"`
 	SSHEnv             string `flag:"ssh-env" desc:"Use predefined ssh options for environment."`
 	NumNodes           int    `flag:"num-nodes" desc:"Number of nodes in the cluster."`

--- a/kubetest2-ec2/pkg/deployer/up.go
+++ b/kubetest2-ec2/pkg/deployer/up.go
@@ -174,6 +174,7 @@ func (d *deployer) NewAWSRunner() *AWSRunner {
 		deployer:           d,
 		instanceNamePrefix: "tmp-e2e-" + uuid.New().String()[:8],
 		token:              utils.RandomFixedLengthString(6) + "." + utils.RandomFixedLengthString(16),
+		certificateKey:     utils.RandomHexEncodedBytes(32),
 	}
 	return d.runner
 }

--- a/kubetest2-ec2/pkg/deployer/utils/random.go
+++ b/kubetest2-ec2/pkg/deployer/utils/random.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"bytes"
+	"encoding/hex"
 	"math/rand"
 	"time"
 )
@@ -33,4 +34,12 @@ func RandomFixedLengthString(length int) string {
 		buffer.WriteByte(charset[seededRand.Intn(len(charset))])
 	}
 	return buffer.String()
+}
+
+func RandomHexEncodedBytes(n int) string {
+	byteArray := make([]byte, n)
+	if _, err := rand.Read(byteArray); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(byteArray)
 }


### PR DESCRIPTION
Tested by hand using:

```
go install . && kubetest2 ec2 \
    --build \
    --target-build-arch linux/amd64 \
    --stage provider-aws-test-infra-dims \
    --worker-image ami-0e0b0f2cb811d16b0 \
    --num-nodes 1 \
    --worker-user-data-file config/al2.sh \
    --up \
    --test=ginkgo \
    -- \
    --use-built-binaries true \
    --focus-regex='should get a host IP'
```