### PR TITLE
Add support for AL2023 EKS images

### DIFF
--- a/hack/populate-s3.sh
+++ b/hack/populate-s3.sh
@@ -56,7 +56,7 @@ pushd "$(go env GOPATH)/src/k8s.io/kubernetes" >/dev/null
 
 popd
 
-[[ ! -d "$(go env GOPATH)/src/kubernetes-sigs/aws-iam-authenticator" ]] && \
+[[ ! -d "$(go env GOPATH)/src/sigs.k8s.io/aws-iam-authenticator" ]] && \
   git clone https://github.com/kubernetes-sigs/aws-iam-authenticator "$(go env GOPATH)/src/sigs.k8s.io/aws-iam-authenticator"
 
 # Generate aws-iam-authenticator binaries

--- a/kubetest2-ec2/config/al2023.sh
+++ b/kubetest2-ec2/config/al2023.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -o xtrace
+set -xeuo pipefail
+
+echo "testing!"
+
+if [ "$(uname -m)" = "arm64" ] || [ "$(uname -m)" = "aarch64" ]; then
+  ARCH=arm64
+else
+  ARCH=amd64
+fi
+
+mkdir -p /etc/kubernetes/
+cat << EOF > /etc/kubernetes/kubeadm-join.yaml
+apiVersion: kubeadm.k8s.io/v1beta3
+kind: JoinConfiguration
+discovery:
+  bootstrapToken:
+    apiServerEndpoint: {{KUBEADM_CONTROL_PLANE_IP}}:6443
+    token: {{KUBEADM_TOKEN}}
+    unsafeSkipCAVerification: true
+nodeRegistration:
+  criSocket: unix:///run/containerd/containerd.sock
+  name: {{HOSTNAME_OVERRIDE}}
+  kubeletExtraArgs:
+    cloud-provider: {{EXTERNAL_CLOUD_PROVIDER}}
+    provider-id: {{PROVIDER_ID}}
+    node-ip: {{NODE_IP}}
+    hostname-override: {{HOSTNAME_OVERRIDE}}
+    image-credential-provider-bin-dir: /etc/eks/image-credential-provider/
+    image-credential-provider-config: /etc/eks/image-credential-provider/config.json
+    resolv-conf: /etc/resolv.conf
+EOF
+
+TOKEN=$(curl --request PUT "http://169.254.169.254/latest/api/token" --header "X-aws-ec2-metadata-token-ttl-seconds: 3600" -s)
+META_URL=http://169.254.169.254/latest/meta-data
+AVAILABILITY_ZONE=$(curl -s $META_URL/placement/availability-zone --header "X-aws-ec2-metadata-token: $TOKEN")
+INSTANCE_ID=$(curl -s $META_URL/instance-id --header "X-aws-ec2-metadata-token: $TOKEN")
+PROVIDER_ID="aws:///$AVAILABILITY_ZONE/$INSTANCE_ID"
+PRIVATE_DNS_NAME=$(curl -s $META_URL/hostname --header "X-aws-ec2-metadata-token: $TOKEN")
+NODE_IP=$(curl -s $META_URL/local-ipv4 --header "X-aws-ec2-metadata-token: $TOKEN")
+
+sed -i "s|{{PROVIDER_ID}}|$PROVIDER_ID|g" /etc/kubernetes/kubeadm-join.yaml
+sed -i "s|{{HOSTNAME_OVERRIDE}}|$PRIVATE_DNS_NAME|g" /etc/kubernetes/kubeadm-join.yaml
+sed -i "s|{{NODE_IP}}|$NODE_IP|g" /etc/kubernetes/kubeadm-join.yaml
+
+VERSION="v1.28.0"
+curl -sSL --fail --retry 5 https://storage.googleapis.com/k8s-artifacts-cri-tools/release/$VERSION/crictl-$VERSION-linux-$ARCH.tar.gz | sudo tar -xvzf - -C /usr/local/bin
+
+RELEASE_VERSION="v0.16.4"
+curl -sSL "https://raw.githubusercontent.com/kubernetes/release/${RELEASE_VERSION}/cmd/krel/templates/latest/kubelet/kubelet.service" | sed "s:/usr/bin:/bin:g" | sudo tee /etc/systemd/system/kubelet.service
+sudo mkdir -p /etc/systemd/system/kubelet.service.d
+curl -sSL "https://raw.githubusercontent.com/kubernetes/release/${RELEASE_VERSION}/cmd/krel/templates/latest/kubeadm/10-kubeadm.conf" | sed "s:/usr/bin:/bin:g" | sudo tee /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+systemctl enable --now kubelet
+
+# shellcheck disable=SC2050
+if [[ "{{STAGING_BUCKET}}" =~ ^s3.*  ]]; then
+  aws s3 cp "{{STAGING_BUCKET}}/{{STAGING_VERSION}}/kubernetes-server-linux-$ARCH.tar.gz" "kubernetes-server-linux-$ARCH.tar.gz"
+elif [[ "{{STAGING_BUCKET}}" =~ ^https.*  ]]; then
+  curl -sSLo kubernetes-server-linux-$ARCH.tar.gz --fail --retry 5 "{{STAGING_BUCKET}}/{{STAGING_VERSION}}/kubernetes-server-linux-$ARCH.tar.gz"
+else
+  aws s3 cp "s3://{{STAGING_BUCKET}}/{{STAGING_VERSION}}/kubernetes-server-linux-$ARCH.tar.gz" "kubernetes-server-linux-$ARCH.tar.gz"
+fi
+
+tar -xvzf kubernetes-server-linux-$ARCH.tar.gz
+cp ./kubernetes/server/bin/* /usr/local/bin/
+
+systemctl start containerd
+
+# shellcheck disable=SC2038
+find . -name "*.tar" -print | xargs -L 1 ctr -n k8s.io images import
+# shellcheck disable=SC2016
+ctr -n k8s.io images ls -q | grep -e $ARCH | xargs -L 1 -I '{}' /bin/bash -c 'ctr -n k8s.io images tag "{}" "$(echo "{}" | sed s/-'$ARCH':/:/)"'
+
+# shellcheck disable=SC2155
+export PATH=$PATH:/usr/local/bin
+
+kubeadm join \
+   --v 10 \
+   --config /etc/kubernetes/kubeadm-join.yaml


### PR DESCRIPTION
fix a typo in populate-s3.sh as well

tested by hand using:
```
go install . && kubetest2 ec2 \
    --build \
    --target-build-arch linux/amd64 \
    --stage provider-aws-test-infra-dims-west-2 \
    --worker-image ami-0272ac35db54e22cb \
    --region us-west-2 \
    --num-nodes 1 \
    --worker-user-data-file config/al2023.sh \
    --up \
    --test=ginkgo \
    -- \
    --use-built-binaries true \
    --focus-regex='should get a host IP'
```

NOTES:
- containerd needs to be explicitly started
- Get instance metadata needs a token -  https://medium.com/@sumitkumar.it81/get-instance-metadata-in-amazon-linux-2023-al2023-e4bf0611d0ad