### PR TITLE
Drop some things from the nodes

### DIFF
--- a/kubetest2-ec2/config/al2023.sh
+++ b/kubetest2-ec2/config/al2023.sh
@@ -2,7 +2,8 @@
 set -o xtrace
 set -xeuo pipefail
 
-echo "testing!"
+# this package is known to stomp on ip addr/link etc
+yum remove -y amazon-ec2-net-utils
 
 if [ "$(uname -m)" = "arm64" ] || [ "$(uname -m)" = "aarch64" ]; then
   ARCH=arm64

--- a/kubetest2-ec2/config/ubuntu2204.yaml
+++ b/kubetest2-ec2/config/ubuntu2204.yaml
@@ -173,6 +173,7 @@ write_files:
     permissions: '0544'
 runcmd:
   - ufw disable || echo "ufw not installed"
+  - apt -y remove rpcbind
   - systemctl stop apparmor
   - systemctl disable apparmor
   - iptables -F && iptables -X  && iptables -t nat -F  && iptables -t nat -X && iptables -t mangle -F  && iptables -t mangle -X  && iptables -P INPUT ACCEPT  && iptables -P FORWARD ACCEPT && iptables -P OUTPUT ACCEPT


### PR DESCRIPTION
- amazon-ec2-net-utils interferes with the ip addr/rules etc.
- rpcbind has some vulns, and we don't really need it