### PR TITLE
Add rpcbind back, for nfs

### DIFF
--- a/kubetest2-ec2/config/ubuntu2204.yaml
+++ b/kubetest2-ec2/config/ubuntu2204.yaml
@@ -174,7 +174,6 @@ write_files:
     permissions: '0544'
 runcmd:
   - ufw disable || echo "ufw not installed"
-  - apt -y remove rpcbind
   - systemctl stop apparmor
   - systemctl disable apparmor
   - iptables -F && iptables -X  && iptables -t nat -F  && iptables -t nat -X && iptables -t mangle -F  && iptables -t mangle -X  && iptables -P INPUT ACCEPT  && iptables -P FORWARD ACCEPT && iptables -P OUTPUT ACCEPT


### PR DESCRIPTION
NFS tests have been failing because the `mount.nfs` helper is missing:
```
Nov 30 23:25:44.020: INFO: At 2023-11-30 23:10:47 +0000 UTC - event for pvc-volume-tester-writer-4khdp: {kubelet ip-172-31-25-49.ec2.internal} FailedMount: MountVolume.SetUp failed for volume "pvc-3057a841-83d6-4fe1-a5c3-30eadb40c235" : mount failed: exit status 32
Mounting command: mount
Mounting arguments: -t nfs -o relatime,vers=4.1 172.31.26.195:/export/pvc-3057a841-83d6-4fe1-a5c3-30eadb40c235 /var/lib/kubelet/pods/2912148a-e10d-4d0f-80cb-56ab36409961/volumes/kubernetes.io~nfs/pvc-3057a841-83d6-4fe1-a5c3-30eadb40c235
Output: mount: /var/lib/kubelet/pods/2912148a-e10d-4d0f-80cb-56ab36409961/volumes/kubernetes.io~nfs/pvc-3057a841-83d6-4fe1-a5c3-30eadb40c235: bad option; for several filesystems (e.g. nfs, cifs) you might need a /sbin/mount.<type> helper program.
```

Removing `rpcbind` also removes `nfs-common`. AFAICT, you can't have `nfs-common` without `rpcbind`.

```
> apt install nfs-common
...
The following NEW packages will be installed:
  nfs-common rpcbind
```

No other package provides `mount.nfs`: https://packages.ubuntu.com/search?searchon=contents&keywords=mount.nfs&mode=exactfilename&suite=kinetic&arch=any