### PR TITLE
switch arm64 instance type to more closely match the amd64 one

### DIFF
--- a/kubetest2-ec2/pkg/deployer/deployer.go
+++ b/kubetest2-ec2/pkg/deployer/deployer.go
@@ -46,7 +46,7 @@ import (
 const Name = "ec2"
 
 const defaultAMD64InstanceType = "r5d.4xlarge"
-const defaultARM64InstanceTYpe = "r7g.4xlarge"
+const defaultARM64InstanceTYpe = "r7gd.4xlarge"
 
 var GitTag string
 


### PR DESCRIPTION
- https://aws.amazon.com/ec2/instance-types/r7g/
- https://aws.amazon.com/ec2/instance-types/r5/

```
Instance Size  vCPU  Memory (GiB)  Instance Storage (GB)  Networking Performance (Gbps)  EBS Bandwidth (Mbps)
r5d.4xlarge     16      128          2 x 300 NVMe SSD        Up to 10                       4,750

Instance Size  vCPU  Memory (GiB)  Instance Storage (GB)  Network Bandwidth (Gbps)      EBS Bandwidth (Gbps)
r7gd.4xlarge    16      128          1 x 950 NVMe SSD        Up to 15                       Up to 10
```