### PR TITLE
Switch back to containerd 2.x.x

### DIFF
--- a/config/al2023-6.1.yaml
+++ b/config/al2023-6.1.yaml
@@ -8,7 +8,7 @@ write_files:
   - path: /tmp/bootstrap/extra-fetches.yaml
     content: |
       # valid keys are containerd-env, and extra_init
-      containerd-env: https://raw.githubusercontent.com/kubernetes/test-infra/master/jobs/e2e_node/containerd/containerd-release-1.7/env
+      containerd-env: https://raw.githubusercontent.com/kubernetes/test-infra/master/jobs/e2e_node/containerd/containerd-main/env
   - path: /etc/systemd/system/containerd-installation.service
     permissions: 0644
     owner: root

--- a/config/ubuntu2204.yaml
+++ b/config/ubuntu2204.yaml
@@ -12,7 +12,7 @@ write_files:
   - path: /tmp/bootstrap/extra-fetches.yaml
     content: |
       # valid keys are containerd-env, and extra_init
-      containerd-env: https://raw.githubusercontent.com/kubernetes/test-infra/master/jobs/e2e_node/containerd/containerd-release-1.7/env
+      containerd-env: https://raw.githubusercontent.com/kubernetes/test-infra/master/jobs/e2e_node/containerd/containerd-main/env
   - path: /etc/systemd/system/containerd-installation.service
     permissions: 0644
     owner: root

--- a/kubetest2-ec2/config/ubuntu2204.yaml
+++ b/kubetest2-ec2/config/ubuntu2204.yaml
@@ -18,7 +18,7 @@ write_files:
   - path: /tmp/bootstrap/extra-fetches.yaml
     content: |
       # valid keys are containerd-env, and extra_init
-      containerd-env: https://raw.githubusercontent.com/kubernetes/test-infra/master/jobs/e2e_node/containerd/containerd-release-1.7/env
+      containerd-env: https://raw.githubusercontent.com/kubernetes/test-infra/master/jobs/e2e_node/containerd/containerd-main/env
   - path: /etc/systemd/system/containerd-installation.service
     permissions: 0644
     owner: root


### PR DESCRIPTION
Snippet from:
```
Feb 07 13:36:48.024915 bootstrap-e2e-master containerd[1191]: time="2024-02-07T13:36:48.024858788Z" level=error msg="PullImage \"registry.k8s.io/kube-apiserver-amd64:v1.30.0-alpha.1.107_052bce26f4f48b\" failed" error="rpc error: code = NotFound desc = failed to pull and unpack image \"registry.k8s.io/kube-apiserver-amd64:v1.30.0-alpha.1.107_052bce26f4f48b\": failed to resolve reference \"registry.k8s.io/kube-apiserver-amd64:v1.30.0-alpha.1.107_052bce26f4f48b\": registry.k8s.io/kube-apiserver-amd64:v1.30.0-alpha.1.107_052bce26f4f48b: not found"
```

Discussion thread:
https://cloud-native.slack.com/archives/GGEQHJ0AE/p1707284414739809?thread_ts=1707230141.026879&cid=GGEQHJ0AE

containerd PR that just merged:
https://github.com/containerd/containerd/pull/9779

artifacts got built:
https://prow.k8s.io/?repo=containerd%2Fcontainerd&type=periodic
