### PR TITLE
drop cri-tools

### DIFF
--- a/hack/build-ami.sh
+++ b/hack/build-ami.sh
@@ -41,6 +41,7 @@ pushd "$(go env GOPATH)/src/github.com/awslabs/amazon-eks-ami" >/dev/null
   sed -i 's/sudo sha256sum.*$//' scripts/install-worker.sh || true
   sed -i 's/.*99-default.link.*$//' scripts/install-worker.sh || true
   sed -i 's/.*amazon-ec2-net-utils.*$//' scripts/install-worker.sh || true
+  sed -i 's/sudo.*cri-tools.*$//' scripts/install-worker.sh || true
 
   cat <<< "$(jq --arg bucket ${S3_BUCKET:-'provider-aws-test-infra'} '.binary_bucket_name = $bucket' eks-worker-al2-variables.json)" > eks-worker-al2-variables.json
   cat <<< "$(jq --arg bucket_region ${AWS_REGION:-'us-east-1'} '.binary_bucket_region = $bucket_region' eks-worker-al2-variables.json)" > eks-worker-al2-variables.json


### PR DESCRIPTION
found https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-ec2-eks-al2023-slow/1755388885224919040/build-log.txt
```
2024-02-08T00:46:42Z:     amazon-ebs: Last metadata expiration check: 0:00:36 ago on Thu Feb  8 00:46:06 2024.
2024-02-08T00:46:42Z:     amazon-ebs: No match for argument: [1mcri-tools(B[m
2024-02-08T00:46:42Z:     amazon-ebs: Error: Unable to find a match: cri-tools
2024-02-08T00:46:42Z: ==> amazon-ebs: Provisioning step had errors: Running the cleanup provisioner, if present...
2024-02-08T00:46:42Z: ==> amazon-ebs: Terminating the source AWS instance...
```