### PR TITLE
Try main branch of amazon-eks-ami ahead of the switch

### DIFF
--- a/hack/build-ami.sh
+++ b/hack/build-ami.sh
@@ -26,6 +26,13 @@ curl -fsSL https://releases.hashicorp.com/packer/1.9.1/packer_1.9.1_linux_amd64.
   mkdir -p "$(go env GOPATH)/src/github.com/awslabs" && \
   git clone https://github.com/awslabs/amazon-eks-ami "$(go env GOPATH)/src/github.com/awslabs/amazon-eks-ami"
 
+# The default branch of this repository will be changed to main from master on February 29, 2024
+pushd "$(go env GOPATH)/src/github.com/awslabs/amazon-eks-ami" >/dev/null
+  if [[ "$(git rev-parse --abbrev-ref HEAD)" != "main" ]]; then
+    git checkout -b main origin/main
+  fi
+popd
+
 pushd "$(go env GOPATH)/src/k8s.io/kubernetes" >/dev/null
   KUBE_FULL_VERSION=$(hack/print-workspace-status.sh | grep gitVersion | awk '{print $2}')
   KUBE_VERSION=$(echo $KUBE_FULL_VERSION | sed -E 's/v([0-9]+)\.([0-9]+)\.([0-9]+).*/v\1.\2.\3/')


### PR DESCRIPTION
<img width="1015" alt="image" src="https://github.com/kubernetes-sigs/provider-aws-test-infra/assets/23304/b25a6d78-ba53-4f5b-85f8-f84a16da77b6">

note above from https://github.com/awslabs/amazon-eks-ami/blob/master/README.md