### PR TITLE
inject config.toml directly

### DIFF
--- a/config/userdata-al2023.sh
+++ b/config/userdata-al2023.sh
@@ -27,11 +27,35 @@ cat << __ECNI__ | sudo tee /etc/cni/net.d/10-testcni.conflist
 }
 __ECNI__
 
-# use the EKS AMI version of the containerd config
-cp /etc/eks/containerd/containerd-config.toml /etc/containerd/config.toml
-# rewrite the pause image url
-sed -i'' 's#SANDBOX_IMAGE#registry.k8s.io/pause:3.8#' /etc/containerd/config.toml
-# use cgroupfs as the containerd cgroup driver
-sed -i'' 's#SystemdCgroup = .*#SystemdCgroup = true#' /etc/containerd/config.toml
+# one of the CRI tests needs an extra "test-handler" so add that at the end
+cat <<EOF > /etc/containerd/config.toml
+version = 2
+root = "/var/lib/containerd"
+state = "/run/containerd"
+# Users can use the following import directory to add additional
+# configuration to containerd. The imports do not behave exactly like overrides.
+# see: https://github.com/containerd/containerd/blob/main/docs/man/containerd-config.toml.5.md#format
+imports = ["/etc/containerd/config.d/*.toml"]
+[grpc]
+address = "/run/containerd/containerd.sock"
+[plugins."io.containerd.grpc.v1.cri".containerd]
+default_runtime_name = "runc"
+discard_unpacked_layers = true
+[plugins."io.containerd.grpc.v1.cri"]
+sandbox_image = "registry.k8s.io/pause:3.8"
+[plugins."io.containerd.grpc.v1.cri".registry]
+config_path = "/etc/containerd/certs.d:/etc/docker/certs.d"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+runtime_type = "io.containerd.runc.v2"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+SystemdCgroup = true
+[plugins."io.containerd.grpc.v1.cri".cni]
+bin_dir = "/opt/cni/bin"
+conf_dir = "/etc/cni/net.d"
+# Setup a runtime with the magic name ("test-handler") used for Kubernetes
+# runtime class tests ...
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler]
+  runtime_type = "io.containerd.runc.v2"
+EOF
 
 systemctl restart containerd

--- a/config/userdata.sh
+++ b/config/userdata.sh
@@ -27,12 +27,37 @@ cat << __ECNI__ | sudo tee /etc/cni/net.d/10-testcni.conflist
 }
 __ECNI__
 
-# use the EKS AMI version of the containerd config
-cp /etc/eks/containerd/containerd-config.toml /etc/containerd/config.toml
-# rewrite the pause image url
-sed -i'' 's#SANDBOX_IMAGE#registry.k8s.io/pause:3.8#' /etc/containerd/config.toml
-# use cgroupfs as the containerd cgroup driver
-sed -i'' 's#SystemdCgroup = .*#SystemdCgroup = false#' /etc/containerd/config.toml
+# one of the CRI tests needs an extra "test-handler" so add that at the end
+cat <<EOF > /etc/containerd/config.toml
+version = 2
+root = "/var/lib/containerd"
+state = "/run/containerd"
+# Users can use the following import directory to add additional
+# configuration to containerd. The imports do not behave exactly like overrides.
+# see: https://github.com/containerd/containerd/blob/main/docs/man/containerd-config.toml.5.md#format
+imports = ["/etc/containerd/config.d/*.toml"]
+[grpc]
+address = "/run/containerd/containerd.sock"
+[plugins."io.containerd.grpc.v1.cri".containerd]
+default_runtime_name = "runc"
+discard_unpacked_layers = true
+[plugins."io.containerd.grpc.v1.cri"]
+sandbox_image = "registry.k8s.io/pause:3.8"
+[plugins."io.containerd.grpc.v1.cri".registry]
+config_path = "/etc/containerd/certs.d:/etc/docker/certs.d"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+runtime_type = "io.containerd.runc.v2"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+SystemdCgroup = true
+[plugins."io.containerd.grpc.v1.cri".cni]
+bin_dir = "/opt/cni/bin"
+conf_dir = "/etc/cni/net.d"
+# Setup a runtime with the magic name ("test-handler") used for Kubernetes
+# runtime class tests ...
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler]
+  runtime_type = "io.containerd.runc.v2"
+EOF
+
 systemctl restart containerd
 
 # hack systemd-run so it ignores the "-p StandardError=file:///some/file.log" option that isn't supported


### PR DESCRIPTION
newer EKS ami image does not come with extra bits we relied on before.