### PR TITLE
Support running presubmits against containerd repository

### DIFF
--- a/kubetest2-ec2/config/configure.sh
+++ b/kubetest2-ec2/config/configure.sh
@@ -125,14 +125,12 @@ if [ "${CONTAINERD_TEST:-"false"}"  != "true" ]; then
 else
   deploy_path=${CONTAINERD_DEPLOY_PATH:-"cri-containerd-staging"}
 
-  # TODO(upodroid) Revisit pull_refs
-  # PULL_REFS_METADATA is the metadata key of PULL_REFS from prow.
-  # PULL_REFS_METADATA="PULL_REFS"
-  # pull_refs=$(fetch_metadata "${PULL_REFS_METADATA}")
-  # if [ ! -z "${pull_refs}" ]; then
-  #   deploy_dir=$(echo "${pull_refs}" | sha1sum | awk '{print $1}')
-  #   deploy_path="${deploy_path}/containerd/${deploy_dir}"
-  # fi
+  pull_refs="{{CONTAINERD_PULL_REFS}}"
+  if [ ! -z "${pull_refs}" ]; then
+    pkg_prefix="containerd-cni"
+    deploy_dir=$(echo "${pull_refs}" | sha1sum | awk '{print $1}')
+    deploy_path="k8s-staging-cri-tools/containerd/${deploy_dir}"
+  fi
 
   # TODO(random-liu): Put version into the metadata instead of
   # deciding it in cloud init. This may cause issue to reboot test.

--- a/kubetest2-ec2/pkg/deployer/runner.go
+++ b/kubetest2-ec2/pkg/deployer/runner.go
@@ -346,7 +346,10 @@ func (a *AWSRunner) getUserData(dataFile string, version string, controlPlane bo
 	userdata = strings.ReplaceAll(userdata, "{{KUBEADM_CERTIFICATE_KEY}}", a.certificateKey)
 	userdata = strings.ReplaceAll(userdata, "{{KUBEADM_CLUSTER_ID}}", a.deployer.ClusterID)
 
-	script, err := utils.FetchConfigureScript(dataFile)
+	script, err := utils.FetchConfigureScript(dataFile, func(data string) string {
+		data = strings.ReplaceAll(data, "{{CONTAINERD_PULL_REFS}}", os.Getenv("CONTAINERD_PULL_REFS"))
+		return data
+	})
 	if err != nil {
 		return "", fmt.Errorf("unable to fetch script : %w", err)
 	}

--- a/kubetest2-ec2/pkg/deployer/utils/userdata.go
+++ b/kubetest2-ec2/pkg/deployer/utils/userdata.go
@@ -43,7 +43,7 @@ func gzipAndBase64Encode(fileBytes []byte) (string, error) {
 	return base64.StdEncoding.EncodeToString(buffer.Bytes()), nil
 }
 
-func FetchConfigureScript(userDataFile string) (string, error) {
+func FetchConfigureScript(userDataFile string, replace func(string) string) (string, error) {
 	var scriptBytes []byte
 	var err error
 	if userDataFile != "" {
@@ -61,6 +61,7 @@ func FetchConfigureScript(userDataFile string) (string, error) {
 			return "", fmt.Errorf("error reading configure script file: %w", err)
 		}
 	}
+	scriptBytes = []byte(replace(string(scriptBytes)))
 	return gzipAndBase64Encode(scriptBytes)
 }
 


### PR DESCRIPTION
`pull-containerd-node-e2e` is for running node e2e tests against containerd. we need something similar to run other tests in k/k as well against containerd master. this is the first step. being able to construct and use a url to download and run a containerd built from the PR pull refs