### PR TITLE
Add support for `runtime-config` and `feature-gates` for apiserver

### DIFF
--- a/kubetest2-ec2/config/kubeadm-init.yaml
+++ b/kubetest2-ec2/config/kubeadm-init.yaml
@@ -21,6 +21,8 @@ kubernetesVersion: {{KUBERNETES_VERSION}}
 apiServer:
   extraArgs:
     cloud-provider: {{EXTERNAL_CLOUD_PROVIDER}}
+    feature-gates: {{FEATURE_GATES}}
+    runtime-config: {{RUNTIME_CONFIG}}
   certSANs:
   - {{EXTRA_SANS}}
 controllerManager:

--- a/kubetest2-ec2/pkg/deployer/deployer.go
+++ b/kubetest2-ec2/pkg/deployer/deployer.go
@@ -125,6 +125,8 @@ type deployer struct {
 	WorkerUserDataFile string `flag:"worker-user-data-file" desc:"Path to user data to pass to worker node instances (aws)"`
 	KubeadmInitFile    string `desc:"custom kubeadm-init config file (aws)"`
 	KubeadmJoinFile    string `desc:"custom kubeadm-join config file (aws)"`
+	RuntimeConfig      string `desc:"If set, API versions can be turned on or off while bringing up the API server."`
+	FeatureGates       string `desc:"A set of key=value pairs that describe feature gates for alpha/experimental features."`
 	InstanceProfile    string `desc:"The name of the instance profile to assign to the node (aws)"`
 	RoleName           string `desc:"The name of the role assign to the node (aws)"`
 	Ec2InstanceConnect bool   `desc:"Use EC2 instance connect to generate a one time use key (aws)"`

--- a/kubetest2-ec2/pkg/deployer/runner.go
+++ b/kubetest2-ec2/pkg/deployer/runner.go
@@ -367,6 +367,8 @@ func (a *AWSRunner) getUserData(dataFile string, version string, controlPlane bo
 
 	yamlString, err := utils.FetchKubeadmInitYaml(a.deployer.KubeadmInitFile, func(data string) string {
 		data = strings.ReplaceAll(data, "{{EXTERNAL_CLOUD_PROVIDER}}", provider)
+		data = strings.ReplaceAll(data, "{{RUNTIME_CONFIG}}", a.deployer.RuntimeConfig)
+		data = strings.ReplaceAll(data, "{{FEATURE_GATES}}", a.deployer.FeatureGates)
 		return data
 	})
 	if err != nil {


### PR DESCRIPTION
We'll need these to model jobs like `ci-kubernetes-e2e-gci-gce-alpha-enabled-default` and `ci-kubernetes-e2e-gci-gce-alpha-features`

https://cs.k8s.io/?q=name%3A%20ci-kubernetes-e2e-gci-gce-alpha&i=nope&files=&excludeFiles=&repos=kubernetes/test-infra
