### PR TITLE
Add rules for ip masquerade

### DIFF
--- a/config/userdata-al2023.sh
+++ b/config/userdata-al2023.sh
@@ -26,7 +26,7 @@ cat << __ECNI__ | sudo tee /etc/cni/net.d/10-testcni.conflist
       "type": "bridge",
       "bridge": "cni0",
       "isGateway": true,
-      "ipMasq": true,
+      "ipMasq": false,
       "ipam": {
         "type": "host-local",
         "subnet": "10.22.0.0/16",

--- a/config/userdata.sh
+++ b/config/userdata.sh
@@ -26,7 +26,7 @@ cat << __ECNI__ | sudo tee /etc/cni/net.d/10-testcni.conflist
       "type": "bridge",
       "bridge": "cni0",
       "isGateway": true,
-      "ipMasq": true,
+      "ipMasq": false,
       "ipam": {
         "type": "host-local",
         "subnet": "10.22.0.0/16",

--- a/kubetest2-ec2/config/al2023.sh
+++ b/kubetest2-ec2/config/al2023.sh
@@ -10,6 +10,23 @@ yum install git -y
 # Note that the `iptables -P FORWARD ACCEPT` piece is load bearing! https://github.com/search?q=repo%3Aawslabs%2Famazon-eks-ami+%22iptables+-P%22&type=code
 iptables -F && iptables -X  && iptables -t nat -F  && iptables -t nat -X && iptables -t mangle -F  && iptables -t mangle -X  && iptables -P INPUT ACCEPT  && iptables -P FORWARD ACCEPT -w 5 && iptables -P OUTPUT ACCEPT -w 5
 
+echo "Add rules for ip masquerade"
+iptables -w -t nat -N IP-MASQ
+iptables -w -t nat -A POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ
+iptables -w -t nat -A IP-MASQ -d 169.254.0.0/16 -m comment --comment "ip-masq: local traffic is not subject to MASQUERADE" -j RETURN
+iptables -w -t nat -A IP-MASQ -d 10.0.0.0/8 -m comment --comment "ip-masq: RFC 1918 reserved range is not subject to MASQUERADE" -j RETURN
+iptables -w -t nat -A IP-MASQ -d 172.16.0.0/12 -m comment --comment "ip-masq: RFC 1918 reserved range is not subject to MASQUERADE" -j RETURN
+iptables -w -t nat -A IP-MASQ -d 192.168.0.0/16 -m comment --comment "ip-masq: RFC 1918 reserved range is not subject to MASQUERADE" -j RETURN
+iptables -w -t nat -A IP-MASQ -d 240.0.0.0/4 -m comment --comment "ip-masq: RFC 5735 reserved range is not subject to MASQUERADE" -j RETURN
+iptables -w -t nat -A IP-MASQ -d 192.0.2.0/24 -m comment --comment "ip-masq: RFC 5737 reserved range is not subject to MASQUERADE" -j RETURN
+iptables -w -t nat -A IP-MASQ -d 198.51.100.0/24 -m comment --comment "ip-masq: RFC 5737 reserved range is not subject to MASQUERADE" -j RETURN
+iptables -w -t nat -A IP-MASQ -d 203.0.113.0/24 -m comment --comment "ip-masq: RFC 5737 reserved range is not subject to MASQUERADE" -j RETURN
+iptables -w -t nat -A IP-MASQ -d 100.64.0.0/10 -m comment --comment "ip-masq: RFC 6598 reserved range is not subject to MASQUERADE" -j RETURN
+iptables -w -t nat -A IP-MASQ -d 198.18.0.0/15 -m comment --comment "ip-masq: RFC 6815 reserved range is not subject to MASQUERADE" -j RETURN
+iptables -w -t nat -A IP-MASQ -d 192.0.0.0/24 -m comment --comment "ip-masq: RFC 6890 reserved range is not subject to MASQUERADE" -j RETURN
+iptables -w -t nat -A IP-MASQ -d 192.88.99.0/24 -m comment --comment "ip-masq: RFC 7526 reserved range is not subject to MASQUERADE" -j RETURN
+iptables -w -t nat -A IP-MASQ -m comment --comment "ip-masq: outbound traffic is subject to MASQUERADE (must be last in chain)" -j MASQUERADE
+
 if [ "$(uname -m)" = "arm64" ] || [ "$(uname -m)" = "aarch64" ]; then
   ARCH=arm64
 else

--- a/kubetest2-ec2/config/ubuntu2204.yaml
+++ b/kubetest2-ec2/config/ubuntu2204.yaml
@@ -17,7 +17,6 @@ packages:
 write_files:
   - path: /tmp/bootstrap/extra-fetches.yaml
     content: |
-      # valid keys are containerd-env, and extra_init
       containerd-env: https://raw.githubusercontent.com/kubernetes/test-infra/master/jobs/e2e_node/containerd/containerd-main/env
   - path: /etc/systemd/system/containerd-installation.service
     permissions: 0644
@@ -50,8 +49,6 @@ write_files:
       KillMode=process
       OOMScoreAdjust=-999
       LimitNOFILE=1048576
-      # Having non-zero Limit*s causes performance problems due to accounting overhead
-      # in the kernel. We recommend using cgroups to do container-local accounting.
       LimitNPROC=infinity
       LimitCORE=infinity
       TasksMax=infinity
@@ -94,7 +91,6 @@ write_files:
     permissions: 0644
     owner: root
     content: |
-      # Note: This dropin only works with kubeadm and kubelet v1.11+
       [Service]
       Environment="KUBELET_EXTRA_ARGS=--image-credential-provider-bin-dir=/usr/local/bin --image-credential-provider-config=/etc/kubernetes/credential-provider.yaml"
       Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
@@ -151,11 +147,24 @@ runcmd:
   - systemctl stop apparmor
   - systemctl disable apparmor
   - iptables -F && iptables -X  && iptables -t nat -F  && iptables -t nat -X && iptables -t mangle -F  && iptables -t mangle -X  && iptables -P INPUT ACCEPT  && iptables -P FORWARD ACCEPT -w 5 && iptables -P OUTPUT ACCEPT -w 5
-  # Ensure instance-id resolves to the ip address of the host
   - "TOKEN=$(curl --request PUT 'http://169.254.169.254/latest/api/token' --header 'X-aws-ec2-metadata-token-ttl-seconds: 3600' -s) && echo \"$(curl -s -f -m 1 http://169.254.169.254/latest/meta-data/local-ipv4 --header 'X-aws-ec2-metadata-token: '$TOKEN) $(curl -s -f -m 1 http://169.254.169.254/latest/meta-data/instance-id/ --header 'X-aws-ec2-metadata-token: '$TOKEN)\" | sudo tee -a /etc/hosts"
   - "sed -i \"s/^#ReadEtcHosts/ReadEtcHosts/\" /etc/systemd/resolved.conf"
-  # Fix issues with no networking from pods
   - "sed -i \"s/^MACAddressPolicy=.*/MACAddressPolicy=none/\" /usr/lib/systemd/network/99-default.link"
+  - iptables -w -t nat -N IP-MASQ
+  - iptables -w -t nat -A POSTROUTING -m addrtype ! --dst-type LOCAL -j IP-MASQ
+  - iptables -w -t nat -A IP-MASQ -d 169.254.0.0/16 -j RETURN
+  - iptables -w -t nat -A IP-MASQ -d 10.0.0.0/8 -j RETURN
+  - iptables -w -t nat -A IP-MASQ -d 172.16.0.0/12 -j RETURN
+  - iptables -w -t nat -A IP-MASQ -d 192.168.0.0/16 -j RETURN
+  - iptables -w -t nat -A IP-MASQ -d 240.0.0.0/4 -j RETURN
+  - iptables -w -t nat -A IP-MASQ -d 192.0.2.0/24 -j RETURN
+  - iptables -w -t nat -A IP-MASQ -d 198.51.100.0/24 -j RETURN
+  - iptables -w -t nat -A IP-MASQ -d 203.0.113.0/24 -j RETURN
+  - iptables -w -t nat -A IP-MASQ -d 100.64.0.0/10 -j RETURN
+  - iptables -w -t nat -A IP-MASQ -d 198.18.0.0/15 -j RETURN
+  - iptables -w -t nat -A IP-MASQ -d 192.0.0.0/24 -j RETURN
+  - iptables -w -t nat -A IP-MASQ -d 192.88.99.0/24 -j RETURN
+  - iptables -w -t nat -A IP-MASQ -j MASQUERADE
   - systemctl restart systemd-resolved
   - rm /usr/lib/systemd/logind.conf.d/unattended-upgrades-logind-maxdelay.conf
   - systemctl restart systemd-logind


### PR DESCRIPTION
Related to https://github.com/kubernetes/kubernetes/issues/126089

copied the masquerading related iptables entries from k/k repo:
https://cs.k8s.io/?q=iptables&i=nope&files=cluster%2Fgce%2Fgci%2Fconfigure-helper.sh&excludeFiles=&repos=kubernetes/kubernetes