### PR TITLE
Avoid coredns loop by skipping reading etc hosts file

### DIFF
--- a/config/ubuntu2204.yaml
+++ b/config/ubuntu2204.yaml
@@ -68,7 +68,7 @@ write_files:
 runcmd:
   # Ensure instance-id resolves to the ip address of the host
   - "echo \"$(dig $(curl -s -f -m 1 http://169.254.169.254/latest/meta-data/instance-id/).ec2.internal +short) $(curl -s -f -m 1 http://169.254.169.254/latest/meta-data/instance-id/)\" | sudo tee -a /etc/hosts"
-  - "sudo sed -i \"s/^#ReadEtcHosts/ReadEtcHosts/\" /etc/systemd/resolved.conf"
+  - "sudo sed -i \"s/^.*ReadEtcHosts.*/ReadEtcHosts=no/\" /etc/systemd/resolved.conf"
   - sudo systemctl restart systemd-resolved
   - sudo rm /usr/lib/systemd/logind.conf.d/unattended-upgrades-logind-maxdelay.conf
   - sudo systemctl restart systemd-logind


### PR DESCRIPTION
```
[INFO] plugin/reload: Running configuration SHA512 = 591cf328cccc12bc490481273e738df59329c62c0b729d94e8b61db9961c2fa5f046dd37f1cf888b953814040d180f52594972691cd6ff41be96639138a43908
CoreDNS-1.11.1
linux/arm64, go1.20.7, ae2bbc2
[FATAL] plugin/loop: Loop (172.31.0.2:60606 -> :53) detected for zone ".", see https://coredns.io/plugins/loop#troubleshooting. Query: "HINFO 1723865833739751426.5954253132454464401."

ENDLOG for container kube-system:coredns-5cfdc65f69-2cc4l:coredns
[FAILED] Error waiting for all pods to be running and ready: Timed out after 600.000s.
```