### PR TITLE
Skip us-east-1e for now

### DIFF
--- a/kubetest2-ec2/pkg/deployer/utils/ec2.go
+++ b/kubetest2-ec2/pkg/deployer/utils/ec2.go
@@ -187,6 +187,10 @@ func getSubnetIDs(svc *ec2.EC2, vpcID string) ([]string, error) {
 
 	var subnetIDs []string
 	for _, subnet := range result.Subnets {
+		// skip known AZ where instance types we need are not available
+		if *subnet.AvailabilityZone == "us-east-1e" {
+			continue
+		}
 		subnetIDs = append(subnetIDs, *subnet.SubnetId)
 	}
 


### PR DESCRIPTION
for example from https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-ec2-alpha-enabled-default/1816085067617800192/build-log.txt
```
I0724 12:19:56.394868    3311 dump.go:30] copying logs to /logs/artifacts/logs
Error: unable to launch instance : creating instance, Unsupported: Your requested instance type (r5d.xlarge) is not supported in your requested Availability Zone (us-east-1e). Please retry your request by not specifying an Availability Zone or choosing us-east-1a, us-east-1b, us-east-1c, us-east-1d, us-east-1f.
	status code: 400, request id: 49ab3728-497e-4946-b9fb-e89135785cd3
```

this started happening since we are now picking a subnet (earlier we left to chance!)