### PR TITLE
Add more logging for kubetest2-ec2 assignNewSSHKey

### DIFF
--- a/kubetest2-ec2/pkg/deployer/runner.go
+++ b/kubetest2-ec2/pkg/deployer/runner.go
@@ -638,6 +638,7 @@ func (a *AWSRunner) assignNewSSHKey(testInstance *awsInstance) error {
 	}
 	if key == nil {
 		// create our new key
+		klog.Infof("assigning new SSH key-pair for %s@%s", a.deployer.SSHUser, testInstance.publicIP)
 		key, err = utils.GenerateSSHKeypair()
 		if err != nil {
 			return fmt.Errorf("creating SSH key, %w", err)
@@ -653,6 +654,7 @@ func (a *AWSRunner) assignNewSSHKey(testInstance *awsInstance) error {
 	if err != nil {
 		return fmt.Errorf("sending SSH Public key for serial console access for %s, %w", a.deployer.SSHUser, err)
 	}
+	klog.Infof("dialing ssh %s@%s", a.deployer.SSHUser, testInstance.publicIP)
 	client, err := ssh.Dial("tcp", fmt.Sprintf("%s:22", testInstance.publicIP), &ssh.ClientConfig{
 		User:            a.deployer.SSHUser,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),


### PR DESCRIPTION
Would be nice to have a log message before dialing ssh, so that it is more clear that there is some network/ACL issue blocking cluster up in the case of misconfiguration. 

Feel free to close issue if no longer relevant due to #352. 

Thanks!

Example default logs post this change:

```
I0726 14:42:41.244968 4090793 ec2.go:149] Randomly picked subnet ID: subnet-023a4c75427d3819d
I0726 14:42:47.786442 4090793 runner.go:602] launched new instance i-0f102a247f3296f85 with ami-id: ami-013b3de8a8fa9b39f on instance type: r5d.xlarge
I0726 14:42:47.786469 4090793 up.go:139] started instance id: i-0f102a247f3296f85
I0726 14:42:47.786519 4090793 runner.go:228] waiting for i-0f102a247f3296f85 to start (5 mins)
I0726 14:42:48.338819 4090793 runner.go:274] instance-connect flag is set, using ec2 instance connect to configure a temporary SSH key
I0726 14:42:48.338882 4090793 runner.go:626] loading existing id_rsa key
I0726 14:42:48.647816 4090793 runner.go:657] dialing ssh ec2-user@54.224.196.85
I0726 14:42:54.166382 4090793 runner.go:602] launched new instance i-0f6c3bdb68cd5b9ca with ami-id: ami-013b3de8a8fa9b39f on instance type: r5d.xlarge
...
I0726 14:43:00.611443 4090793 up.go:139] started instance id: i-0cdf66590b3e0f8de
I0726 14:43:00.611461 4090793 runner.go:228] waiting for i-0cdf66590b3e0f8de to start (5 mins)
I0726 14:43:01.142358 4090793 runner.go:274] instance-connect flag is set, using ec2 instance connect to configure a temporary SSH key
I0726 14:43:01.142409 4090793 runner.go:626] loading existing id_rsa key
I0726 14:43:01.443452 4090793 runner.go:657] dialing ssh ec2-user@3.81.139.175
```

