### PR TITLE
Upload to a temp location based on run id and then switch it the actual location

### DIFF
--- a/kubetest2-ec2/config/al2023.sh
+++ b/kubetest2-ec2/config/al2023.sh
@@ -233,7 +233,7 @@ else
   echo "Waiting to see if s3://$BUCKET/$KEY is being updated..."
   wait_for_update "$BUCKET" "$KEY"
 
-  aws s3 cp "s3://$BUCKET/$KEY" "$FILE_NAME"
+  aws s3 cp --no-progress "s3://$BUCKET/$KEY" "$FILE_NAME"
 fi
 
 tar -xvzf kubernetes-server-linux-$ARCH.tar.gz

--- a/kubetest2-ec2/pkg/deployer/build.go
+++ b/kubetest2-ec2/pkg/deployer/build.go
@@ -45,6 +45,7 @@ func (d *deployer) Build() error {
 		u.Concurrency = 10
 	})
 
+	d.BuildOptions.CommonBuildOptions.S3Service = d.runner.s3Service
 	d.BuildOptions.CommonBuildOptions.S3Uploader = s3Uploader
 	d.BuildOptions.CommonBuildOptions.RepoRoot = d.RepoRoot
 

--- a/kubetest2-ec2/pkg/deployer/build/options.go
+++ b/kubetest2-ec2/pkg/deployer/build/options.go
@@ -18,6 +18,7 @@ package build
 
 import (
 	s3managerv2 "github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
 type Options struct {
@@ -25,6 +26,8 @@ type Options struct {
 	RepoRoot        string `flag:"-"`
 	StageVersion    string `flag:"~version" desc:"Specify version already in s3 bucket"`
 	TargetBuildArch string `flag:"~target-build-arch" desc:"Target architecture for the test artifacts"`
+	RunID           string `flag:"-"`
+	S3Service       *s3v2.Client
 	S3Uploader      *s3managerv2.Uploader
 	Builder
 	Stager
@@ -40,8 +43,10 @@ func (o *Options) implementationFromStrategy() error {
 		TargetBuildArch: o.TargetBuildArch,
 	}
 	o.Stager = &S3Stager{
+		RunID:           o.RunID,
 		RepoRoot:        o.RepoRoot,
 		StageLocation:   o.StageLocation,
+		s3Service:       o.S3Service,
 		s3Uploader:      o.S3Uploader,
 		TargetBuildArch: o.TargetBuildArch,
 	}

--- a/kubetest2-ec2/pkg/deployer/deployer.go
+++ b/kubetest2-ec2/pkg/deployer/deployer.go
@@ -79,6 +79,7 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 		commonOptions:         opts,
 		BuildOptions: &options.BuildOptions{
 			CommonBuildOptions: &build.Options{
+				RunID: opts.RunID(),
 				Builder: &build.MakeBuilder{
 					TargetBuildArch: "linux/amd64",
 				},

--- a/kubetest2-ec2/pkg/deployer/runner.go
+++ b/kubetest2-ec2/pkg/deployer/runner.go
@@ -356,6 +356,7 @@ func (a *AWSRunner) InitializeServices() (*awsv2.Config, error) {
 	a.ssmService = ssmv2.NewFromConfig(cfg)
 	a.iamService = iamv2.NewFromConfig(cfg)
 	a.s3Service = s3v2.NewFromConfig(cfg)
+	a.deployer.BuildOptions.CommonBuildOptions.S3Service = a.s3Service
 	a.deployer.BuildOptions.CommonBuildOptions.S3Uploader = s3managerv2.NewUploader(a.s3Service, func(u *s3managerv2.Uploader) {
 		u.PartSize = 10 * 1024 * 1024 // 10 MB
 		u.Concurrency = 10


### PR DESCRIPTION
Still trying to track down where things go wrong:

recent log https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-ec2-eks-conformance-latest/1820638086200037376/artifacts/logs/i-0b01c40156ccab6d4/cloud-init-output.log
```
download: s3://provider-aws-test-infra/v1.32.0-alpha.0.18+00236ae0d73d24/kubernetes-server-linux-amd64.tar.gz to ./kubernetes-server-linux-amd64.tar.gz
+ tar -xvzf kubernetes-server-linux-amd64.tar.gz
kubernetes/
kubernetes/server/
kubernetes/server/bin/
kubernetes/server/bin/kube-apiserver
kubernetes/server/bin/kube-controller-manager
kubernetes/server/bin/kube-scheduler
kubernetes/server/bin/kube-proxy
kubernetes/server/bin/kubectl
kubernetes/server/bin/kubectl.tar
kubernetes/server/bin/kubectl.docker_tag
kubernetes/server/bin/kube-scheduler.tar

gzip: stdin: invalid compressed data--format violated
tar: Unexpected EOF in archive
tar: Unexpected EOF in archive
tar: Error is not recoverable: exiting now

```