### PR TITLE
Unify version lookup

### DIFF
--- a/kubetest2-ec2/pkg/deployer/runner.go
+++ b/kubetest2-ec2/pkg/deployer/runner.go
@@ -394,7 +394,6 @@ func (a *AWSRunner) prepareAWSImages() ([]utils.InternalAWSImage, error) {
 
 	err = utils.ValidateS3Bucket(a.s3Service,
 		a.deployer.BuildOptions.CommonBuildOptions.StageLocation,
-		a.deployer.BuildOptions.CommonBuildOptions.StageVersion,
 		version)
 	if err != nil {
 		return nil, fmt.Errorf("unable to validate s3 bucket : %w", err)

--- a/kubetest2-ec2/pkg/deployer/utils/s3.go
+++ b/kubetest2-ec2/pkg/deployer/utils/s3.go
@@ -21,13 +21,15 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/klog/v2"
+
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
 	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
 
 	"golang.org/x/exp/maps"
 )
 
-func ValidateS3Bucket(s3Service *s3v2.Client, stageLocation string, stageVersion string, version string) error {
+func ValidateS3Bucket(s3Service *s3v2.Client, stageLocation string, version string) error {
 	if strings.Contains(stageLocation, "://") {
 		return nil
 	}
@@ -38,29 +40,46 @@ func ValidateS3Bucket(s3Service *s3v2.Client, stageLocation string, stageVersion
 	})
 	if err != nil {
 		return fmt.Errorf("version %s is missing from bucket %s: %w",
-			stageVersion,
+			version,
 			stageLocation,
 			err)
 	} else if results.KeyCount == nil || *results.KeyCount == 0 {
-		results, _ = s3Service.ListObjectsV2(context.TODO(), &s3v2.ListObjectsV2Input{
+		results, err = s3Service.ListObjectsV2(context.TODO(), &s3v2.ListObjectsV2Input{
 			Bucket: awsv2.String(stageLocation),
 			Prefix: awsv2.String("v"),
 		})
 
+		if err != nil {
+			return fmt.Errorf("unable to list items in bucket %s: %w",
+				stageLocation,
+				err)
+		}
+
 		availableVersions := map[string]string{}
 		if results != nil && results.KeyCount != nil && *results.KeyCount > 0 {
+			count := 0
 			for _, item := range results.Contents {
 				dir := strings.Split(*item.Key, "/")[0]
 				if _, ok := availableVersions[dir]; !ok {
+					klog.Infof("Found version %s in bucket %s", dir, stageLocation)
 					availableVersions[dir] = *item.Key
+					klog.Infof("checking if key %s is a prefix of %s", dir, version)
+					if len(version) > len(dir) && strings.HasPrefix(version, dir) {
+						count++
+						klog.Infof("bucket %s has %s for use with %s", stageLocation, dir, version)
+					}
 				}
+			}
+			if count > 0 {
+				return nil
 			}
 		}
 
 		return fmt.Errorf("version %s is missing from bucket %s, choose one of %s",
-			stageVersion,
+			version,
 			stageLocation,
 			maps.Keys(availableVersions))
 	}
+	klog.Infof("found requested version %s in bucket %s", version, stageLocation)
 	return nil
 }


### PR DESCRIPTION
getting failures like these since 1.32 master was opened
```
I0812 20:17:13.233733    4093 dump.go:37] created logs directory /logs/artifacts/logs
Error: while preparing AWS images: unable to validate s3 bucket : version  is missing from bucket provider-aws-test-infra, choose one of [v1.32.0-alpha.0.21+84d0db99e69045 v1.32.0-alpha.0.21+8cf534cb896dcd v1.32.0-alpha.0.21+ede19f94952bc3 v1.32.0-alpha.0.28+27c1b3445b985c v1.32.0-alpha.0.20+e69abfeb22214c v1.32.0-alpha.0.21+a5ff2daa892af1 v1.32.0-alpha.0.21+f638da68513a81 v1.32.0-alpha.0.22+3ee4a7034a25fc v1.32.0-alpha.0.88+03befd96891f1c v1.32.0-alpha.0.20+168807bfb27c15 v1.32.0-alpha.0.20+1eada7370d8f9e v1.32.0-alpha.0.20+e2a4e8de00b018 v1.32.0-alpha.0.21+fa768bc91de69f v1.32.0-alpha.0.22+a9e2cdcdd3f35c v1.32.0-alpha.0.20+4a3b56c89ca175 v1.32.0-alpha.0.20+5851c1122d79d2 v1.32.0-alpha.0.20+857941972bd226 v1.32.0-alpha.0.20+fcb257df994071 v1.32.0-alpha.0.21+c29057ef5cbd6c v1.32.0-alpha.0.22+09d330f0426627 v1.32.0-alpha.0.28+20377a1771b924 v1.32.0-alpha.0.19+60c4c2b2521fb4 v1.32.0-alpha.0.20+456a6916dd83ad v1.32.0-alpha.0.21+492e3fab2c464c v1.32.0-alpha.0.21+872501099e81dc v1.32.0-alpha.0.21+9f940e1124edae v1.32.0-alpha.0.18+00236ae0d73d24 v1.32.0-alpha.0.20+0f1e17465cbc33 v1.32.0-alpha.0.20+13642ef862fc01 v1.32.0-alpha.0.21+d84d9c637bf1dc v1.32.0 v1.32.0-alpha.0.20+d4754b98d22e9a v1.32.0-alpha.0.20+face7de5cdb7fb v1.32.0-alpha.0.21+2e198f81d877f7 v1.32.0-alpha.0.21+4e0d1a4c5032ad v1.32.0-alpha.0.20+03724b9372262e v1.32.0-alpha.0.20+189e87aee0fd2a v1.32.0-alpha.0.21+16062f2ad58261 v1.32.0-alpha.0.22+422c7c1026f317 v1.32.0-alpha.0.23+10c1a28cc2f04b]
+ EXIT_VALUE=1
+ set +o xtrace
```

https://testgrid.k8s.io/amazon-ec2-al2023#ci-kubernetes-e2e-ec2-eks-al2023&width=20