### PR TITLE
Setup runtime.slice for containerd/kubelet

### DIFF
--- a/kubetest2-ec2/config/kubeadm-init.yaml
+++ b/kubetest2-ec2/config/kubeadm-init.yaml
@@ -16,6 +16,10 @@ nodeRegistration:
     image-credential-provider-bin-dir: /usr/local/bin
     image-credential-provider-config: /etc/kubernetes/credential-provider.yaml
     resolv-conf: /run/systemd/resolve/resolv.conf
+    system-cgroups: /system.slice
+    runtime-cgroups: /runtime.slice
+    kubelet-cgroups: /runtime.slice
+    cgroup-root: /
 ---
 apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration

--- a/kubetest2-ec2/config/kubeadm-join.yaml
+++ b/kubetest2-ec2/config/kubeadm-join.yaml
@@ -17,3 +17,7 @@ nodeRegistration:
     image-credential-provider-bin-dir: /usr/local/bin
     image-credential-provider-config: /etc/kubernetes/credential-provider.yaml
     resolv-conf: /run/systemd/resolve/resolv.conf
+    system-cgroups: /system.slice
+    runtime-cgroups: /runtime.slice
+    kubelet-cgroups: /runtime.slice
+    cgroup-root: /

--- a/kubetest2-ec2/config/ubuntu2204.yaml
+++ b/kubetest2-ec2/config/ubuntu2204.yaml
@@ -1,5 +1,4 @@
 #cloud-config
-# This bootstraps a public ubuntu 2204 image from scratch.
 system_info:
   default_user:
     name: ec2-user
@@ -24,7 +23,6 @@ write_files:
     content: |
       # installed by cloud-init
       [Unit]
-      Description=Download and install containerd binaries and configurations.
       After=network-online.target
       [Service]
       Type=oneshot
@@ -33,16 +31,22 @@ write_files:
       ExecStart=/home/containerd/configure.sh
       [Install]
       WantedBy=containerd.target
+  - path: /etc/systemd/system/runtime.slice
+    permissions: 0644
+    owner: root
+    content: |
+      [Unit]
+      Before=slices.target
   - path: /etc/systemd/system/containerd.service
     permissions: 0644
     owner: root
     content: |
       # installed by cloud-init
       [Unit]
-      Description=containerd container runtime
       Documentation=https://containerd.io
       After=containerd-installation.service
       [Service]
+      Slice=runtime.slice
       Restart=always
       RestartSec=5
       Delegate=yes
@@ -104,16 +108,19 @@ write_files:
     owner: root
     content: |
       [Unit]
-      Description=kubelet: The Kubernetes Node Agent
       Documentation=https://kubernetes.io/docs/home/
       Wants=network-online.target
       After=network-online.target
 
       [Service]
+      Slice=runtime.slice
       ExecStart=/usr/local/bin/kubelet
       Restart=always
       StartLimitInterval=0
       RestartSec=10
+      KillMode=process
+      CPUAccounting=true
+      MemoryAccounting=true
 
       [Install]
       WantedBy=multi-user.target

--- a/kubetest2-ec2/pkg/deployer/runner.go
+++ b/kubetest2-ec2/pkg/deployer/runner.go
@@ -410,9 +410,16 @@ func (a *AWSRunner) prepareAWSImages() ([]utils.InternalAWSImage, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to load controlplane user data %s : %w", a.deployer.UserDataFile, err)
 	}
+	if len(userControlPlane) > 16384 { // 16KB
+		return nil, fmt.Errorf("worker user data is too large, must be less than 16384 bytes, is %d\n\n%s", len(userControlPlane), userControlPlane)
+	}
+
 	userDataWorkerNode, err := a.getUserData(a.deployer.WorkerUserDataFile, version, false)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load worker user data %s : %w", a.deployer.WorkerUserDataFile, err)
+	}
+	if len(userDataWorkerNode) > 16384 { // 16KB
+		return nil, fmt.Errorf("worker user data is too large, must be less than 16384 bytes, is %d\n\n%s", len(userDataWorkerNode), userDataWorkerNode)
 	}
 
 	klog.Infof("using %s for control plane image", a.deployer.Image)

--- a/kubetest2-ec2/pkg/deployer/utils/userdata.go
+++ b/kubetest2-ec2/pkg/deployer/utils/userdata.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"bytes"
+	"compress/flate"
 	"compress/gzip"
 	"encoding/base64"
 	"errors"
@@ -30,7 +31,10 @@ import (
 
 func gzipAndBase64Encode(fileBytes []byte) (string, error) {
 	var buffer bytes.Buffer
-	gz := gzip.NewWriter(&buffer)
+	gz, err := gzip.NewWriterLevel(&buffer, flate.BestCompression)
+	if err != nil {
+		return "", err
+	}
 	if _, err := gz.Write(fileBytes); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This PR adds the runtime.slice and makes use of it as recommended in the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/).