### PR TITLE
Move embedded files outside the cloud init yaml

### DIFF
--- a/kubetest2-ec2/config/embed.go
+++ b/kubetest2-ec2/config/embed.go
@@ -2,5 +2,5 @@ package config
 
 import "embed"
 
-//go:embed configure.sh run-kubeadm.sh run-post-install.sh al2023.sh *.yaml
+//go:embed ubuntu configure.sh run-kubeadm.sh run-post-install.sh al2023.sh *.yaml
 var ConfigFS embed.FS

--- a/kubetest2-ec2/config/ubuntu/10-kubeadm.conf
+++ b/kubetest2-ec2/config/ubuntu/10-kubeadm.conf
@@ -1,0 +1,8 @@
+[Service]
+Environment="KUBELET_EXTRA_ARGS=--image-credential-provider-bin-dir=/usr/local/bin --image-credential-provider-config=/etc/kubernetes/credential-provider.yaml"
+Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
+Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
+EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
+EnvironmentFile=-/etc/default/kubelet
+ExecStart=
+ExecStart=/usr/local/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS

--- a/kubetest2-ec2/config/ubuntu/containerd-installation.service
+++ b/kubetest2-ec2/config/ubuntu/containerd-installation.service
@@ -1,0 +1,9 @@
+[Unit]
+After=network-online.target
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStartPre=/bin/chmod 544 /home/containerd/configure.sh
+ExecStart=/home/containerd/configure.sh
+[Install]
+WantedBy=containerd.target

--- a/kubetest2-ec2/config/ubuntu/containerd.service
+++ b/kubetest2-ec2/config/ubuntu/containerd.service
@@ -1,0 +1,18 @@
+[Unit]
+Documentation=https://containerd.io
+After=containerd-installation.service
+[Service]
+Slice=runtime.slice
+Restart=always
+RestartSec=5
+Delegate=yes
+KillMode=process
+OOMScoreAdjust=-999
+LimitNOFILE=1048576
+LimitNPROC=infinity
+LimitCORE=infinity
+TasksMax=infinity
+ExecStartPre=/sbin/modprobe overlay
+ExecStart=/home/containerd/usr/local/bin/containerd
+[Install]
+WantedBy=containerd.target

--- a/kubetest2-ec2/config/ubuntu/containerd.target
+++ b/kubetest2-ec2/config/ubuntu/containerd.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=Containerd
+[Install]
+WantedBy=multi-user.target

--- a/kubetest2-ec2/config/ubuntu/credential-provider.yaml
+++ b/kubetest2-ec2/config/ubuntu/credential-provider.yaml
@@ -1,0 +1,12 @@
+kind: CredentialProviderConfig
+apiVersion: kubelet.config.k8s.io/v1
+providers:
+- name: ecr-credential-provider
+  apiVersion: credentialprovider.kubelet.k8s.io/v1
+  matchImages:
+  - "*.dkr.ecr.*.amazonaws.com"
+  - "*.dkr.ecr.*.amazonaws.com.cn"
+  - "*.dkr.ecr-fips.*.amazonaws.com"
+  - "*.dkr.ecr.us-iso-east-1.c2s.ic.gov"
+  - "*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"
+  defaultCacheDuration: 12h

--- a/kubetest2-ec2/config/ubuntu/kubelet.service
+++ b/kubetest2-ec2/config/ubuntu/kubelet.service
@@ -1,0 +1,17 @@
+[Unit]
+Documentation=https://kubernetes.io/docs/home/
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Slice=runtime.slice
+ExecStart=/usr/local/bin/kubelet
+Restart=always
+StartLimitInterval=0
+RestartSec=10
+KillMode=process
+CPUAccounting=true
+MemoryAccounting=true
+
+[Install]
+WantedBy=multi-user.target

--- a/kubetest2-ec2/config/ubuntu2204.yaml
+++ b/kubetest2-ec2/config/ubuntu2204.yaml
@@ -18,19 +18,10 @@ write_files:
     content: |
       containerd-env: https://raw.githubusercontent.com/kubernetes/test-infra/master/jobs/e2e_node/containerd/containerd-main/env
   - path: /etc/systemd/system/containerd-installation.service
-    permissions: 0644
+    permissions: '0644'
     owner: root
-    content: |
-      # installed by cloud-init
-      [Unit]
-      After=network-online.target
-      [Service]
-      Type=oneshot
-      RemainAfterExit=yes
-      ExecStartPre=/bin/chmod 544 /home/containerd/configure.sh
-      ExecStart=/home/containerd/configure.sh
-      [Install]
-      WantedBy=containerd.target
+    encoding: gzip+base64
+    content: {{CONTAINERD_INSTALL_SERVICE}}
   - path: /etc/systemd/system/runtime.slice
     permissions: 0644
     owner: root
@@ -38,36 +29,15 @@ write_files:
       [Unit]
       Before=slices.target
   - path: /etc/systemd/system/containerd.service
-    permissions: 0644
+    permissions: '0644'
     owner: root
-    content: |
-      # installed by cloud-init
-      [Unit]
-      Documentation=https://containerd.io
-      After=containerd-installation.service
-      [Service]
-      Slice=runtime.slice
-      Restart=always
-      RestartSec=5
-      Delegate=yes
-      KillMode=process
-      OOMScoreAdjust=-999
-      LimitNOFILE=1048576
-      LimitNPROC=infinity
-      LimitCORE=infinity
-      TasksMax=infinity
-      ExecStartPre=/sbin/modprobe overlay
-      ExecStart=/home/containerd/usr/local/bin/containerd
-      [Install]
-      WantedBy=containerd.target
+    encoding: gzip+base64
+    content: {{CONTAINERD_SERVICE}}
   - path: /etc/systemd/system/containerd.target
-    permissions: 0644
+    permissions: '0644'
     owner: root
-    content: |
-      [Unit]
-      Description=Containerd
-      [Install]
-      WantedBy=multi-user.target
+    encoding: gzip+base64
+    content: {{CONTAINERD_TARGET}}
   - path: /etc/sysctl.d/k8s.conf
     permissions: 0644
     owner: root
@@ -76,54 +46,20 @@ write_files:
       net.bridge.bridge-nf-call-ip6tables = 1
       net.bridge.bridge-nf-call-iptables = 1
   - path: /etc/kubernetes/credential-provider.yaml
-    permissions: 0644
+    permissions: '0644'
     owner: root
-    content: |
-      kind: CredentialProviderConfig
-      apiVersion: kubelet.config.k8s.io/v1
-      providers:
-      - name: ecr-credential-provider
-        apiVersion: credentialprovider.kubelet.k8s.io/v1
-        matchImages:
-        - "*.dkr.ecr.*.amazonaws.com"
-        - "*.dkr.ecr.*.amazonaws.com.cn"
-        - "*.dkr.ecr-fips.*.amazonaws.com"
-        - "*.dkr.ecr.us-iso-east-1.c2s.ic.gov"
-        - "*.dkr.ecr.us-isob-east-1.sc2s.sgov.gov"
-        defaultCacheDuration: 12h
+    encoding: gzip+base64
+    content: {{CREDENTIAL_PROVIDER_YAML}}
   - path: /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
-    permissions: 0644
+    permissions: '0644'
     owner: root
-    content: |
-      [Service]
-      Environment="KUBELET_EXTRA_ARGS=--image-credential-provider-bin-dir=/usr/local/bin --image-credential-provider-config=/etc/kubernetes/credential-provider.yaml"
-      Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
-      Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
-      EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
-      EnvironmentFile=-/etc/default/kubelet
-      ExecStart=
-      ExecStart=/usr/local/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS
+    encoding: gzip+base64
+    content: {{KUBEADM_CONF}}
   - path: /usr/lib/systemd/system/kubelet.service
-    permissions: 0644
+    permissions: '0644'
     owner: root
-    content: |
-      [Unit]
-      Documentation=https://kubernetes.io/docs/home/
-      Wants=network-online.target
-      After=network-online.target
-
-      [Service]
-      Slice=runtime.slice
-      ExecStart=/usr/local/bin/kubelet
-      Restart=always
-      StartLimitInterval=0
-      RestartSec=10
-      KillMode=process
-      CPUAccounting=true
-      MemoryAccounting=true
-
-      [Install]
-      WantedBy=multi-user.target
+    encoding: gzip+base64
+    content: {{KUBELET_SERVICE}}
   - path: /usr/local/bin/run-kubeadm.sh
     permissions: '0755'
     owner: root

--- a/kubetest2-ec2/pkg/deployer/runner.go
+++ b/kubetest2-ec2/pkg/deployer/runner.go
@@ -530,6 +530,13 @@ func (a *AWSRunner) getUserData(dataFile string, version string, controlPlane bo
 	}
 	userdata = strings.ReplaceAll(userdata, "{{RUN_KUBEADM_SH}}", scriptString)
 
+	userdata = strings.ReplaceAll(userdata, "{{CONTAINERD_INSTALL_SERVICE}}", utils.FetchUbuntuFile("ubuntu/containerd-installation.service"))
+	userdata = strings.ReplaceAll(userdata, "{{CONTAINERD_SERVICE}}", utils.FetchUbuntuFile("ubuntu/containerd.service"))
+	userdata = strings.ReplaceAll(userdata, "{{CONTAINERD_TARGET}}", utils.FetchUbuntuFile("ubuntu/containerd.target"))
+	userdata = strings.ReplaceAll(userdata, "{{KUBEADM_CONF}}", utils.FetchUbuntuFile("ubuntu/10-kubeadm.conf"))
+	userdata = strings.ReplaceAll(userdata, "{{KUBELET_SERVICE}}", utils.FetchUbuntuFile("ubuntu/kubelet.service"))
+	userdata = strings.ReplaceAll(userdata, "{{CREDENTIAL_PROVIDER_YAML}}", utils.FetchUbuntuFile("ubuntu/credential-provider.yaml"))
+
 	userdata = strings.ReplaceAll(userdata, "{{FEATURE_GATES}}", a.deployer.FeatureGates)
 	userdata = strings.ReplaceAll(userdata, "{{EXTERNAL_CLOUD_PROVIDER}}", provider)
 	userdata = strings.ReplaceAll(userdata, "{{EXTERNAL_CLOUD_PROVIDER_IMAGE}}", a.deployer.ExternalCloudProviderImage)

--- a/kubetest2-ec2/pkg/deployer/utils/userdata.go
+++ b/kubetest2-ec2/pkg/deployer/utils/userdata.go
@@ -146,3 +146,17 @@ func FetchRunPostInstallSH(replace func(string) string) (string, error) {
 	}
 	return scriptString, nil
 }
+
+func FetchUbuntuFile(fileName string) string {
+	var scriptBytes []byte
+	var err error
+	scriptBytes, err = config.ConfigFS.ReadFile(fileName)
+	if err != nil {
+		panic(fmt.Sprintf("error reading %s: %w", fileName, err))
+	}
+	scriptString, err := gzipAndBase64Encode(scriptBytes)
+	if err != nil {
+		panic(fmt.Sprintf("error encoding %s: %w", fileName, err))
+	}
+	return scriptString
+}


### PR DESCRIPTION
Enables us to pass in the gzip/base64 encoded version of the files into cloud init yaml