### PR TITLE
Download arm64 binaries from GCS bucket as well

### DIFF
--- a/config/configure.sh
+++ b/config/configure.sh
@@ -115,8 +115,10 @@ else
 fi
 
 TARBALL_GCS_NAME="${pkg_prefix}-${version}.linux-${ARCH}.tar.gz"
+ALT_TARBALL_GCS_NAME="${pkg_prefix}-${version}-linux-${ARCH}.tar.gz"
 # TARBALL_GCS_PATH is the path to download cri-containerd tarball for node e2e.
 TARBALL_GCS_PATH="https://storage.googleapis.com/${deploy_path}/${TARBALL_GCS_NAME}"
+ALT_TARBALL_GCS_PATH="https://storage.googleapis.com/${deploy_path}/${ALT_TARBALL_GCS_NAME}"
 # TARBALL is the name of the tarball after being downloaded.
 TARBALL="containerd.tar.gz"
 # CONTAINERD_TAR_SHA1 is the sha1sum of containerd tarball.
@@ -132,21 +134,15 @@ if [ -z "${version}" ]; then
     exit 1
   fi
 else
-  if [ ${ARCH} == "arm64" ]; then
-    version=${version%%-*}
-    curl -f --ipv4 -Lo "${TARBALL}" --connect-timeout 20 --max-time 300 --retry 6 --retry-delay 10 \
-	"https://github.com/containerd/containerd/releases/download/v${version}/cri-containerd-${version}-linux-${ARCH}.tar.gz"
-    tar xvf "${TARBALL}"
-    rm -f "${TARBALL}"
-  elif is_preloaded "${TARBALL_GCS_NAME}" "${tar_sha1}"; then
-    echo "${TARBALL_GCS_NAME} is preloaded"
-  else
-    # Download and untar the release tar ball.
-    $(set +x; curl -X GET "${HEADERS[@]}" -f --ipv4 -Lo "${TARBALL}" --connect-timeout 20 --max-time 300 --retry 6 \
-      --retry-delay 10 "${TARBALL_GCS_PATH}")
-    tar xvf "${TARBALL}"
-    rm -f "${TARBALL}"
-  fi
+  # Download and untar the release tar ball, there are two alternate names for the
+  # tar.gz files unfortunately, so this is a temporary respite until the fixes
+  # are in place
+  $(set +x; curl -X GET "${HEADERS[@]}" -f --ipv4 -Lo "${TARBALL}" --connect-timeout 20 --max-time 300 --retry 6 \
+    --retry-delay 10 "${ALT_TARBALL_GCS_PATH}") || \
+  $(set +x; curl -X GET "${HEADERS[@]}" -f --ipv4 -Lo "${TARBALL}" --connect-timeout 20 --max-time 300 --retry 6 \
+    --retry-delay 10 "${TARBALL_GCS_PATH}")
+  tar xvf "${TARBALL}"
+  rm -f "${TARBALL}"
 fi
 
 # Remove crictl shipped with containerd, use crictl installed


### PR DESCRIPTION
We are building arm64 tgz(s) for 1.7/2.0 and main branches of containerd:
- https://github.com/kubernetes/test-infra/pull/33771
- https://github.com/kubernetes/test-infra/pull/33774

Unfortunately there's a typo `-` vs `.` in the file name which is being rectified in:
- https://github.com/containerd/containerd/pull/10964
- https://github.com/containerd/containerd/pull/10967
- https://github.com/containerd/containerd/pull/10968

So until everything lands have a mitigation in place here to try both url(s).
