### PR TITLE
Revert "Stick to containerd 1.7 environment"

### DIFF
--- a/config/al2023-6.1.yaml
+++ b/config/al2023-6.1.yaml
@@ -8,7 +8,7 @@ write_files:
   - path: /tmp/bootstrap/extra-fetches.yaml
     content: |
       # valid keys are containerd-env, and extra_init
-      containerd-env: https://raw.githubusercontent.com/kubernetes/test-infra/master/jobs/e2e_node/containerd/containerd-release-1.7/env
+      containerd-env: https://raw.githubusercontent.com/kubernetes/test-infra/master/jobs/e2e_node/containerd/containerd-main/env
   - path: /etc/systemd/system/containerd-installation.service
     permissions: 0644
     owner: root

--- a/config/ubuntu2204.yaml
+++ b/config/ubuntu2204.yaml
@@ -12,7 +12,7 @@ write_files:
   - path: /tmp/bootstrap/extra-fetches.yaml
     content: |
       # valid keys are containerd-env, and extra_init
-      containerd-env: https://raw.githubusercontent.com/kubernetes/test-infra/master/jobs/e2e_node/containerd/containerd-release-1.7/env
+      containerd-env: https://raw.githubusercontent.com/kubernetes/test-infra/master/jobs/e2e_node/containerd/containerd-main/env
   - path: /etc/systemd/system/containerd-installation.service
     permissions: 0644
     owner: root

--- a/kubetest2-ec2/config/ubuntu2204.yaml
+++ b/kubetest2-ec2/config/ubuntu2204.yaml
@@ -16,7 +16,7 @@ packages:
 write_files:
   - path: /tmp/bootstrap/extra-fetches.yaml
     content: |
-      containerd-env: https://raw.githubusercontent.com/kubernetes/test-infra/master/jobs/e2e_node/containerd/containerd-release-1.7/env
+      containerd-env: https://raw.githubusercontent.com/kubernetes/test-infra/master/jobs/e2e_node/containerd/containerd-main/env
   - path: /etc/systemd/system/containerd-installation.service
     permissions: '0644'
     owner: root


### PR DESCRIPTION
Reverts kubernetes-sigs/provider-aws-test-infra#382

with https://github.com/kubernetes-sigs/provider-aws-test-infra/pull/385 and the PRs linked from there, we should be all set to go back to `main`