### PR TITLE
enable cdi for aws containerd jobs

### DIFF
--- a/config/userdata-al2023.sh
+++ b/config/userdata-al2023.sh
@@ -57,6 +57,7 @@ default_runtime_name = "runc"
 discard_unpacked_layers = true
 [plugins."io.containerd.grpc.v1.cri"]
 sandbox_image = "registry.k8s.io/pause:3.8"
+enable_cdi = true
 [plugins."io.containerd.grpc.v1.cri".registry]
 config_path = "/etc/containerd/certs.d:/etc/docker/certs.d"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]

--- a/config/userdata.sh
+++ b/config/userdata.sh
@@ -57,6 +57,7 @@ default_runtime_name = "runc"
 discard_unpacked_layers = true
 [plugins."io.containerd.grpc.v1.cri"]
 sandbox_image = "registry.k8s.io/pause:3.8"
+enable_cdi = true
 [plugins."io.containerd.grpc.v1.cri".registry]
 config_path = "/etc/containerd/certs.d:/etc/docker/certs.d"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]

--- a/kubetest2-ec2/config/al2023.sh
+++ b/kubetest2-ec2/config/al2023.sh
@@ -302,6 +302,7 @@ discard_unpacked_layers = true
 
 [plugins."io.containerd.grpc.v1.cri"]
 sandbox_image = "registry.k8s.io/pause:3.8"
+enable_cdi = true
 
 [plugins."io.containerd.grpc.v1.cri".registry]
 config_path = "/etc/containerd/certs.d:/etc/docker/certs.d"


### PR DESCRIPTION
Mimic https://github.com/kubernetes/test-infra/pull/34013.

CDI tests are failing on containerd jobs.

https://testgrid.k8s.io/sig-node-ec2

This hopefully should fix this.

