### PR TITLE
Remove the deprecated cloud provider flag for apiserver

### DIFF
--- a/kubetest2-ec2/config/kubeadm-init.yaml
+++ b/kubetest2-ec2/config/kubeadm-init.yaml
@@ -26,7 +26,6 @@ kind: ClusterConfiguration
 kubernetesVersion: {{KUBERNETES_VERSION}}
 apiServer:
   extraArgs:
-    cloud-provider: {{EXTERNAL_CLOUD_PROVIDER}}
     feature-gates: {{FEATURE_GATES}}
     runtime-config: {{RUNTIME_CONFIG}}
   certSANs:


### PR DESCRIPTION
the cloud provider flag is deprecated and also removed from the apiserver flag options. https://github.com/kubernetes/kubernetes/pull/130162