### PR TITLE
cd to k8sRoot before running script

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e_node/builder/build.go
+++ b/vendor/k8s.io/kubernetes/test/e2e_node/builder/build.go
@@ -78,6 +78,7 @@ func BuildTargets(cgo bool) error {
 		// Multi-architecture build is only supported in dockerized build
 		cmd = exec.Command(filepath.Join(k8sRoot, "build/run.sh"), "make", fmt.Sprintf("WHAT=%s", what), fmt.Sprintf("KUBE_BUILD_PLATFORMS=%s", GetTargetBuildArch()))
 	}
+	cmd.Dir = k8sRoot
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()


### PR DESCRIPTION
Builds seems to be picking up git information from this repo instead of the k8s repo. So set the directory explicitly.