### PR TITLE
copy `runc` binary to $PATH

### DIFF
--- a/config/configure.sh
+++ b/config/configure.sh
@@ -143,6 +143,8 @@ else
     --retry-delay 10 "${TARBALL_GCS_PATH}")
   tar xvf "${TARBALL}"
   rm -f "${TARBALL}"
+  # copy `runc` in ${CONTAINERD_HOME} to a directory in PATH as well
+  cp usr/local/sbin/runc /bin/runc || true
 fi
 
 # Remove crictl shipped with containerd, use crictl installed

--- a/kubetest2-ec2/config/configure.sh
+++ b/kubetest2-ec2/config/configure.sh
@@ -152,6 +152,8 @@ else
     --retry-delay 10 "${TARBALL_GCS_PATH}")
   tar xvf "${TARBALL}"
   rm -f "${TARBALL}"
+  # copy `runc` in ${CONTAINERD_HOME} to a directory in PATH as well
+  cp usr/local/sbin/runc /bin/runc || true
 fi
 
 # Remove crictl shipped with containerd, use crictl installed


### PR DESCRIPTION
Fix for https://github.com/kubernetes/test-infra/pull/34510

Apparently some of the node test scenarios require `runc` to be present in PATH as well.

Please see https://github.com/containerd/containerd/pull/11557 for traffic