### PR TITLE
pin to a older ubuntu 24.04 kernel

### DIFF
--- a/config/aws-instance-arm64.yaml
+++ b/config/aws-instance-arm64.yaml
@@ -4,6 +4,6 @@ images:
     instance_type: m6g.large
     user_data_file: al2023-6.1.yaml
   ubuntu-2404:
-    ssm_path: /aws/service/canonical/ubuntu/server/noble/stable/current/arm64/hvm/ebs-gp3/ami-id
+    ssm_path: /aws/service/canonical/ubuntu/server/24.04/stable/20250305/arm64/hvm/ebs-gp3/ami-id
     instance_type: m6g.large
     user_data_file: ubuntu2404.yaml

--- a/config/aws-instance.yaml
+++ b/config/aws-instance.yaml
@@ -4,6 +4,6 @@ images:
     instance_type: m6a.large
     user_data_file: al2023-6.1.yaml
   ubuntu-2404:
-    ssm_path: /aws/service/canonical/ubuntu/server/noble/stable/current/amd64/hvm/ebs-gp3/ami-id
+    ssm_path: /aws/service/canonical/ubuntu/server/24.04/stable/20250305/amd64/hvm/ebs-gp3/ami-id
     instance_type: m6a.large
     user_data_file: ubuntu2404.yaml

--- a/kubetest2-ec2/pkg/deployer/runner.go
+++ b/kubetest2-ec2/pkg/deployer/runner.go
@@ -120,7 +120,7 @@ func (a *AWSRunner) Validate() error {
 				a.deployer.UserDataFile = "al2023.sh"
 			}
 		case "ubuntu", "":
-			path = "/aws/service/canonical/ubuntu/server/noble/stable/current/" + arch + "/hvm/ebs-gp3/ami-id"
+			path = "/aws/service/canonical/ubuntu/server/24.04/stable/20250305/" + arch + "/hvm/ebs-gp3/ami-id"
 			if a.deployer.UserDataFile == "" {
 				a.deployer.UserDataFile = "ubuntu2404.yaml"
 			}
@@ -182,7 +182,7 @@ func (a *AWSRunner) Validate() error {
 				a.deployer.WorkerUserDataFile = "al2023.sh"
 			}
 		case "ubuntu", "":
-			path = "/aws/service/canonical/ubuntu/server/noble/stable/current/" + arch + "/hvm/ebs-gp3/ami-id"
+			path = "/aws/service/canonical/ubuntu/server/24.04/stable/20250305/" + arch + "/hvm/ebs-gp3/ami-id"
 			if a.deployer.WorkerUserDataFile == "" {
 				a.deployer.WorkerUserDataFile = "ubuntu2404.yaml"
 			}


### PR DESCRIPTION
We need to downgrade from `6.8.0-1025-aws` to `6.8.0-1024-aws`

Fix for failures mentioned in : https://github.com/kubernetes/kubernetes/issues/131094
Related to those already talked about in : https://github.com/kubernetes/kubernetes/issues/129280

Related to the upstream ubuntu bug: https://bugs.launchpad.net/ubuntu/+source/linux-aws/+bug/2101914

Let's see if we can revive this CI job:
https://testgrid.k8s.io/amazon-ec2#ci-cloud-provider-aws-e2e-kubetest2&width=20

```
❯ aws ssm get-parameters --names \
        /aws/service/canonical/ubuntu/server/24.04/stable/20250305/amd64/hvm/ebs-gp3/ami-id \
    --query 'Parameters[0].[Value]' --output text
ami-075686beab831bb7f
```