### PR TITLE
Bump Kubernetes on (04/19/2025)

### DIFF
--- a/vendor/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/vendor/k8s.io/apiserver/pkg/features/kube_features.go
@@ -415,5 +415,7 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	WatchList: {
 		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
+		// switch this back to false because the json and proto streaming encoders appear to work better.
+		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Beta},
 	},
 }

--- a/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
+++ b/vendor/k8s.io/kubernetes/pkg/features/kube_features.go
@@ -1339,6 +1339,8 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	genericfeatures.WatchList: {
 		{Version: version.MustParse("1.27"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.Beta},
+		// switch this back to false because the json and proto streaming encoders appear to work better.
+		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Beta},
 	},
 
 	GitRepoVolumeDriver: {


### PR DESCRIPTION
PR filed with output of running hack/bump-k8s.sh on Date: 04/19/2025