### PR TITLE
Bump Kubernetes on (04/23/2025)

### DIFF
--- a/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
+++ b/vendor/k8s.io/kubernetes/test/utils/image/manifest.go
@@ -223,7 +223,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[APIServer] = Config{list.PromoterE2eRegistry, "sample-apiserver", "1.29.2"}
 	configs[AppArmorLoader] = Config{list.PromoterE2eRegistry, "apparmor-loader", "1.4"}
 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.36.1-1"}
-	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.7.3"}
+	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.7.4"}
 	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.5.21-0"}
 	configs[Httpd] = Config{list.PromoterE2eRegistry, "httpd", "2.4.38-4"}
 	configs[HttpdNew] = Config{list.PromoterE2eRegistry, "httpd", "2.4.39-4"}


### PR DESCRIPTION
PR filed with output of running hack/bump-k8s.sh on Date: 04/23/2025