### PR TITLE
force containerd 1.7 for now in AL2/AL2023 builds - take 2

### DIFF
--- a/hack/build-ami.sh
+++ b/hack/build-ami.sh
@@ -85,12 +85,15 @@ pushd "$(go env GOPATH)/src/github.com/awslabs/amazon-eks-ami" >/dev/null
     cat <<< "$(jq --arg aws_region ${AWS_REGION:-'us-east-1'} '.aws_region = $aws_region' templates/al2/variables-default.json)" > templates/al2/variables-default.json || true
     cat <<< "$(jq --arg instance_profile ${INSTANCE_PROFILE_NAME:-'packer-instance-profile'} '.iam_instance_profile = $instance_profile' templates/al2/variables-default.json)" > templates/al2/variables-default.json || true
     cat <<< "$(jq --arg pause_container_image ${PAUSE_CONTAINER_IMAGE:-'registry.k8s.io/pause:3.10'} '.pause_container_image = $pause_container_image' templates/al2/variables-default.json)" > templates/al2/variables-default.json || true
+    cat <<< "$(jq --arg containerd_version ${CONTAINERD_VERSION:-"1.7.*"} '.containerd_version = $containerd_version' templates/al2/variables-default.json)" > templates/al2/variables-default.json || true
+
 
     cat <<< "$(jq --arg bucket ${S3_BUCKET:-'provider-aws-test-infra'} '.binary_bucket_name = $bucket' templates/al2023/variables-default.json)" > templates/al2023/variables-default.json || true
     cat <<< "$(jq --arg bucket_region ${AWS_REGION:-'us-east-1'} '.binary_bucket_region = $bucket_region' templates/al2023/variables-default.json)" > templates/al2023/variables-default.json || true
     cat <<< "$(jq --arg aws_region ${AWS_REGION:-'us-east-1'} '.aws_region = $aws_region' templates/al2023/variables-default.json)" > templates/al2023/variables-default.json || true
     cat <<< "$(jq --arg instance_profile ${INSTANCE_PROFILE_NAME:-'packer-instance-profile'} '.iam_instance_profile = $instance_profile' templates/al2023/variables-default.json)" > templates/al2023/variables-default.json || true
     cat <<< "$(jq --arg pause_container_image ${PAUSE_CONTAINER_IMAGE:-'registry.k8s.io/pause:3.10'} '.pause_container_image = $pause_container_image' templates/al2023/variables-default.json)" > templates/al2023/variables-default.json || true
+    cat <<< "$(jq --arg containerd_version ${CONTAINERD_VERSION:-"1.7.*"} '.containerd_version = $containerd_version' templates/al2023/variables-default.json)" > templates/al2023/variables-default.json || true
 
     make k8s kubernetes_version=${KUBE_VERSION} kubernetes_build_date=${KUBE_DATE} \
       pull_cni_from_github=true arch=${BUILD_EKS_AMI_ARCH:-"x86_64"} os_distro=${BUILD_EKS_AMI_OS:-"al2"} || true


### PR DESCRIPTION
missed 2 spots in https://github.com/kubernetes-sigs/provider-aws-test-infra/commit/f8f605ae10ab86bdc63a004b73953df6d4d6af4f