### PR TITLE
WIP: Add dual-stack (IPv6) support to kubetest2-ec2 deployer

### DIFF
--- a/kubetest2-ec2/config/kubeadm-init.yaml
+++ b/kubetest2-ec2/config/kubeadm-init.yaml
@@ -1,5 +1,8 @@
 apiVersion: kubeadm.k8s.io/v1beta3
 kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: "{{ADVERTISE_ADDRESS}}"
+  bindPort: 6443
 bootstrapTokens:
 - groups:
   - system:bootstrappers:kubeadm:default-node-token
@@ -11,7 +14,7 @@ nodeRegistration:
     feature-gates: {{FEATURE_GATES}}
     cloud-provider: {{EXTERNAL_CLOUD_PROVIDER}}
     provider-id: {{PROVIDER_ID}}
-    node-ip: {{NODE_IP}}
+    node-ip: "{{NODE_IP}}"
     hostname-override: {{HOSTNAME_OVERRIDE}}
     image-credential-provider-bin-dir: /usr/local/bin
     image-credential-provider-config: /etc/kubernetes/credential-provider.yaml

--- a/kubetest2-ec2/config/kubeadm-init.yaml
+++ b/kubetest2-ec2/config/kubeadm-init.yaml
@@ -38,6 +38,7 @@ scheduler:
   extraArgs:
     feature-gates: {{FEATURE_GATES}}
 networking:
+  serviceSubnet: {{SERVICE_CIDR}}
   podSubnet: {{POD_CIDR}}
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1

--- a/kubetest2-ec2/config/kubeadm-join.yaml
+++ b/kubetest2-ec2/config/kubeadm-join.yaml
@@ -2,7 +2,7 @@ apiVersion: kubeadm.k8s.io/v1beta3
 kind: JoinConfiguration
 discovery:
   bootstrapToken:
-    apiServerEndpoint: {{KUBEADM_CONTROL_PLANE_IP}}:6443
+    apiServerEndpoint: "{{KUBEADM_CONTROL_PLANE_IP}}:6443"
     token: {{BOOTSTRAP_TOKEN}}
     unsafeSkipCAVerification: true
 nodeRegistration:
@@ -12,7 +12,7 @@ nodeRegistration:
     feature-gates: {{FEATURE_GATES}}
     cloud-provider: {{EXTERNAL_CLOUD_PROVIDER}}
     provider-id: {{PROVIDER_ID}}
-    node-ip: {{NODE_IP}}
+    node-ip: "{{NODE_IP}}"
     hostname-override: {{HOSTNAME_OVERRIDE}}
     image-credential-provider-bin-dir: /usr/local/bin
     image-credential-provider-config: /etc/kubernetes/credential-provider.yaml

--- a/kubetest2-ec2/config/run-kubeadm.sh
+++ b/kubetest2-ec2/config/run-kubeadm.sh
@@ -80,6 +80,13 @@ PROVIDER_ID="aws:///$AVAILABILITY_ZONE/$INSTANCE_ID"
 PRIVATE_DNS_NAME=$(curl -s $META_URL/hostname --header "X-aws-ec2-metadata-token: $TOKEN")
 NODE_IP=$(curl -s $META_URL/local-ipv4 --header "X-aws-ec2-metadata-token: $TOKEN")
 
+# Append IPv6 address to NODE_IP if one is assigned (enables dual-stack kubelet registration)
+IFACE_MAC=$(curl -s $META_URL/network/interfaces/macs/ --header "X-aws-ec2-metadata-token: $TOKEN" | head -n 1)
+IPV6_ADDR=$(curl -sf "$META_URL/network/interfaces/macs/${IFACE_MAC}ipv6s" --header "X-aws-ec2-metadata-token: $TOKEN" 2>/dev/null | head -n 1 || true)
+if [ -n "$IPV6_ADDR" ]; then
+    NODE_IP="${NODE_IP},${IPV6_ADDR}"
+fi
+
 sed -i "s|{{PROVIDER_ID}}|$PROVIDER_ID|g" /etc/kubernetes/kubeadm-*.yaml
 sed -i "s|{{HOSTNAME_OVERRIDE}}|$PRIVATE_DNS_NAME|g" /etc/kubernetes/kubeadm-*.yaml
 sed -i "s|{{NODE_IP}}|$NODE_IP|g" /etc/kubernetes/kubeadm-*.yaml

--- a/kubetest2-ec2/config/run-kubeadm.sh
+++ b/kubetest2-ec2/config/run-kubeadm.sh
@@ -80,10 +80,12 @@ PROVIDER_ID="aws:///$AVAILABILITY_ZONE/$INSTANCE_ID"
 PRIVATE_DNS_NAME=$(curl -s $META_URL/hostname --header "X-aws-ec2-metadata-token: $TOKEN")
 NODE_IP=$(curl -s $META_URL/local-ipv4 --header "X-aws-ec2-metadata-token: $TOKEN")
 
-# Append IPv6 address to NODE_IP if one is assigned (enables dual-stack kubelet registration)
-IFACE_MAC=$(curl -s $META_URL/network/interfaces/macs/ --header "X-aws-ec2-metadata-token: $TOKEN" | head -n 1)
-IPV6_ADDR=$(curl -sf "$META_URL/network/interfaces/macs/${IFACE_MAC}ipv6s" --header "X-aws-ec2-metadata-token: $TOKEN" 2>/dev/null | head -n 1 || true)
-[ -n "$IPV6_ADDR" ] && NODE_IP="::"
+IPV6_ADDR=""
+if [[ "{{IP_FAMILY}}" == "dual" ]]; then
+  IFACE_MAC=$(curl -s $META_URL/network/interfaces/macs/ --header "X-aws-ec2-metadata-token: $TOKEN" | head -n 1)
+  IPV6_ADDR=$(curl -sf "$META_URL/network/interfaces/macs/${IFACE_MAC}ipv6s" --header "X-aws-ec2-metadata-token: $TOKEN" 2>/dev/null | head -n 1 || true)
+  [ -n "$IPV6_ADDR" ] && NODE_IP="::"
+fi
 
 sed -i "s|{{PROVIDER_ID}}|$PROVIDER_ID|g" /etc/kubernetes/kubeadm-*.yaml
 sed -i "s|{{HOSTNAME_OVERRIDE}}|$PRIVATE_DNS_NAME|g" /etc/kubernetes/kubeadm-*.yaml
@@ -107,8 +109,10 @@ if [[ ${KUBEADM_CONTROL_PLANE} == true ]]; then
   LOCAL_IP=$(curl -s $META_URL/local-ipv4 --header "X-aws-ec2-metadata-token: $TOKEN")
   FIRST_TWO_OCTETS=$(echo $LOCAL_IP | cut -d'.' -f1,2)
   POD_CIDR=$(curl -s $META_URL/network/interfaces/macs/"$MAC"/vpc-ipv4-cidr-blocks --header "X-aws-ec2-metadata-token: $TOKEN" | grep "$FIRST_TWO_OCTETS.")
-  VPC_IPV6_CIDR=$(curl -sf "$META_URL/network/interfaces/macs/${MAC}vpc-ipv6-cidr-blocks" --header "X-aws-ec2-metadata-token: $TOKEN" 2>/dev/null | head -n 1 || true)
-  [ -n "$VPC_IPV6_CIDR" ] && POD_CIDR="${VPC_IPV6_CIDR},${POD_CIDR}"
+  if [[ "{{IP_FAMILY}}" == "dual" ]]; then
+    VPC_IPV6_CIDR=$(curl -sf "$META_URL/network/interfaces/macs/${MAC}vpc-ipv6-cidr-blocks" --header "X-aws-ec2-metadata-token: $TOKEN" 2>/dev/null | head -n 1 || true)
+    [ -n "$VPC_IPV6_CIDR" ] && POD_CIDR="${VPC_IPV6_CIDR},${POD_CIDR}"
+  fi
 
   sed -i "s|{{BOOTSTRAP_TOKEN}}|{{KUBEADM_TOKEN}}|g" /etc/kubernetes/kubeadm-init.yaml
   EXTRA_SANS=$(curl -s --connect-timeout 3 $META_URL/public-ipv4 --header "X-aws-ec2-metadata-token: $TOKEN")
@@ -116,7 +120,7 @@ if [[ ${KUBEADM_CONTROL_PLANE} == true ]]; then
   KUBERNETES_VERSION=$(kubelet --version | awk '{print $2}')
   sed -i "s|{{KUBERNETES_VERSION}}|$KUBERNETES_VERSION|g" /etc/kubernetes/kubeadm-init.yaml
   sed -i "s|{{POD_CIDR}}|$POD_CIDR|g" /etc/kubernetes/kubeadm-init.yaml
-  if [ -n "$IPV6_ADDR" ]; then
+  if [[ "{{IP_FAMILY}}" == "dual" && -n "$IPV6_ADDR" ]]; then
     sed -i "s|{{ADVERTISE_ADDRESS}}|::|g" /etc/kubernetes/kubeadm-init.yaml
   else
     sed -i "s|{{ADVERTISE_ADDRESS}}|$LOCAL_IP|g" /etc/kubernetes/kubeadm-init.yaml

--- a/kubetest2-ec2/config/run-kubeadm.sh
+++ b/kubetest2-ec2/config/run-kubeadm.sh
@@ -83,9 +83,7 @@ NODE_IP=$(curl -s $META_URL/local-ipv4 --header "X-aws-ec2-metadata-token: $TOKE
 # Append IPv6 address to NODE_IP if one is assigned (enables dual-stack kubelet registration)
 IFACE_MAC=$(curl -s $META_URL/network/interfaces/macs/ --header "X-aws-ec2-metadata-token: $TOKEN" | head -n 1)
 IPV6_ADDR=$(curl -sf "$META_URL/network/interfaces/macs/${IFACE_MAC}ipv6s" --header "X-aws-ec2-metadata-token: $TOKEN" 2>/dev/null | head -n 1 || true)
-if [ -n "$IPV6_ADDR" ]; then
-    NODE_IP="${NODE_IP},${IPV6_ADDR}"
-fi
+[ -n "$IPV6_ADDR" ] && NODE_IP="::"
 
 sed -i "s|{{PROVIDER_ID}}|$PROVIDER_ID|g" /etc/kubernetes/kubeadm-*.yaml
 sed -i "s|{{HOSTNAME_OVERRIDE}}|$PRIVATE_DNS_NAME|g" /etc/kubernetes/kubeadm-*.yaml
@@ -109,6 +107,8 @@ if [[ ${KUBEADM_CONTROL_PLANE} == true ]]; then
   LOCAL_IP=$(curl -s $META_URL/local-ipv4 --header "X-aws-ec2-metadata-token: $TOKEN")
   FIRST_TWO_OCTETS=$(echo $LOCAL_IP | cut -d'.' -f1,2)
   POD_CIDR=$(curl -s $META_URL/network/interfaces/macs/"$MAC"/vpc-ipv4-cidr-blocks --header "X-aws-ec2-metadata-token: $TOKEN" | grep "$FIRST_TWO_OCTETS.")
+  VPC_IPV6_CIDR=$(curl -sf "$META_URL/network/interfaces/macs/${MAC}vpc-ipv6-cidr-blocks" --header "X-aws-ec2-metadata-token: $TOKEN" 2>/dev/null | head -n 1 || true)
+  [ -n "$VPC_IPV6_CIDR" ] && POD_CIDR="${VPC_IPV6_CIDR},${POD_CIDR}"
 
   sed -i "s|{{BOOTSTRAP_TOKEN}}|{{KUBEADM_TOKEN}}|g" /etc/kubernetes/kubeadm-init.yaml
   EXTRA_SANS=$(curl -s --connect-timeout 3 $META_URL/public-ipv4 --header "X-aws-ec2-metadata-token: $TOKEN")
@@ -116,6 +116,11 @@ if [[ ${KUBEADM_CONTROL_PLANE} == true ]]; then
   KUBERNETES_VERSION=$(kubelet --version | awk '{print $2}')
   sed -i "s|{{KUBERNETES_VERSION}}|$KUBERNETES_VERSION|g" /etc/kubernetes/kubeadm-init.yaml
   sed -i "s|{{POD_CIDR}}|$POD_CIDR|g" /etc/kubernetes/kubeadm-init.yaml
+  if [ -n "$IPV6_ADDR" ]; then
+    sed -i "s|{{ADVERTISE_ADDRESS}}|::|g" /etc/kubernetes/kubeadm-init.yaml
+  else
+    sed -i "s|{{ADVERTISE_ADDRESS}}|$LOCAL_IP|g" /etc/kubernetes/kubeadm-init.yaml
+  fi
 
   kubeadm init \
    --v 10 \

--- a/kubetest2-ec2/config/run-post-install.sh
+++ b/kubetest2-ec2/config/run-post-install.sh
@@ -4,9 +4,21 @@ if [[ "${KUBEADM_CONTROL_PLANE}" == true ]]; then
   KC="--kubeconfig /etc/kubernetes/admin.conf"
   # shellcheck disable=SC2050
   if [[ "{{EXTERNAL_CLOUD_PROVIDER}}" == "external" ]]; then
-    CNI_VERSION=v1.21.1
-    kubectl $KC create -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/${CNI_VERSION}/config/master/aws-k8s-cni.yaml
-    kubectl $KC set env daemonset aws-node -n kube-system ENABLE_PREFIX_DELEGATION=true MINIMUM_IP_TARGET=160 WARM_IP_TARGET=20 AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS=10.0.0.0/8
+    if [[ "{{IP_FAMILY}}" == "dual" ]]; then
+      CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable.txt)
+      CLI_ARCH=amd64
+      if [ "$(uname -m)" = "aarch64" ]; then CLI_ARCH=arm64; fi
+      curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
+      sha256sum --check cilium-linux-${CLI_ARCH}.tar.gz.sha256sum
+      tar xzvfC cilium-linux-${CLI_ARCH}.tar.gz /usr/local/bin
+      rm cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
+      HOME=/root cilium install --version 1.18.4 --set cni.chainingMode=portmap --set kubeProxyReplacement=false --set socketLB.enabled=false --set sessionAffinity=true --set externalIPs.enabled=true --set nodePort.enabled=true --set hostPort.enabled=false --set cluster.name=kubernetes --set ipam.mode=kubernetes --set ipv4.enabled=true --set ipv6.enabled=true $KC
+      HOME=/root cilium status --wait $KC
+    else
+      CNI_VERSION=v1.21.1
+      kubectl $KC create -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/${CNI_VERSION}/config/master/aws-k8s-cni.yaml
+      kubectl $KC set env daemonset aws-node -n kube-system ENABLE_PREFIX_DELEGATION=true MINIMUM_IP_TARGET=160 WARM_IP_TARGET=20 AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS=10.0.0.0/8
+    fi
   else
     CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable.txt)
     CLI_ARCH=amd64

--- a/kubetest2-ec2/config/run-post-install.sh
+++ b/kubetest2-ec2/config/run-post-install.sh
@@ -22,7 +22,7 @@ if [[ "${KUBEADM_CONTROL_PLANE}" == true ]]; then
   if [[ "{{EXTERNAL_CLOUD_PROVIDER}}" == "external" ]]; then
     mkdir -p cloud-provider-aws
     for f in kustomization.yaml apiserver-authentication-reader-role-binding.yaml aws-cloud-controller-manager-daemonset.yaml cluster-role-binding.yaml cluster-role.yaml service-account.yaml; do
-      curl -sSLo ./cloud-provider-aws/${f} --fail --retry 5 "https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/master/examples/existing-cluster/base/${f}"
+      curl -sSLo ./cloud-provider-aws/${f} --fail --retry 5 "{{EXTERNAL_CCM_DAEMONSET_URL}}/${f}"
     done
     if [[ "{{EXTERNAL_CLOUD_PROVIDER_IMAGE}}" != "" ]]; then
       sed -i "s|registry.k8s.io/provider-aws/cloud-controller-manager.*$|{{EXTERNAL_CLOUD_PROVIDER_IMAGE}}|" ./cloud-provider-aws/aws-cloud-controller-manager-daemonset.yaml

--- a/kubetest2-ec2/config/ubuntu2404.yaml
+++ b/kubetest2-ec2/config/ubuntu2404.yaml
@@ -42,6 +42,8 @@ write_files:
     owner: root
     content: |
       net.ipv4.ip_forward=1
+      net.ipv6.conf.all.forwarding=1
+      net.ipv6.conf.default.forwarding=1
       net.bridge.bridge-nf-call-ip6tables = 1
       net.bridge.bridge-nf-call-iptables = 1
   - path: /etc/kubernetes/credential-provider.yaml

--- a/kubetest2-ec2/pkg/deployer/deployer.go
+++ b/kubetest2-ec2/pkg/deployer/deployer.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/pkg/deployer/build"
 	"sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/pkg/deployer/options"
 	"sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/pkg/deployer/remote"
+	"sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/pkg/deployer/utils"
 )
 
 // Name is the name of the deployer
@@ -145,6 +146,7 @@ type deployer struct {
 	SSHUser            string `flag:"ssh-user" desc:"The SSH user to use for SSH access to instances"`
 	SSHEnv             string `flag:"ssh-env" desc:"Use predefined ssh options for environment."`
 	NumNodes           int    `flag:"num-nodes" desc:"Number of nodes in the cluster."`
+	IPFamily           string `flag:"ip-family" desc:"IP family for the cluster: ipv4, ipv6, or dual"`
 
 	runner  *AWSRunner
 	logsDir string
@@ -162,6 +164,12 @@ func (d *deployer) Down() error {
 			return fmt.Errorf("failed to delete instance %s : %w", instance.instanceID, err)
 		}
 		klog.Infof("deleted instance id: %s", instance.instanceID)
+	}
+
+	if d.IPFamily != "" && d.IPFamily != "ipv4" && d.runner != nil && d.runner.subnetID != "" {
+		if err := utils.TeardownIPv6Subnet(context.TODO(), d.runner.ec2Service, d.runner.subnetID); err != nil {
+			klog.Warningf("failed to teardown IPv6 subnet %s: %v", d.runner.subnetID, err)
+		}
 	}
 	return nil
 }

--- a/kubetest2-ec2/pkg/deployer/deployer.go
+++ b/kubetest2-ec2/pkg/deployer/deployer.go
@@ -156,6 +156,15 @@ func (d *deployer) Down() error {
 	if err := d.DumpClusterLogs(); err != nil {
 		klog.Warningf("Dumping cluster logs at the start of Down() failed: %s", err)
 	}
+	if d.IPFamily != "" && d.IPFamily != "ipv4" {
+		for _, instance := range d.runner.instances {
+			if instance.networkInterfaceID != "" && instance.ipv6Address != "" {
+				if err := utils.UnassignIPv6FromInstance(context.TODO(), d.runner.ec2Service, instance.networkInterfaceID, instance.ipv6Address); err != nil {
+					klog.Warningf("failed to unassign IPv6 from instance %s: %v", instance.instanceID, err)
+				}
+			}
+		}
+	}
 	for _, instance := range d.runner.instances {
 		_, err := d.runner.ec2Service.TerminateInstances(context.TODO(), &ec2v2.TerminateInstancesInput{
 			InstanceIds: []string{instance.instanceID},

--- a/kubetest2-ec2/pkg/deployer/runner.go
+++ b/kubetest2-ec2/pkg/deployer/runner.go
@@ -63,12 +63,14 @@ type AWSRunner struct {
 }
 
 type awsInstance struct {
-	instance         *ec2typesv2.Instance
-	instanceID       string
-	sshKey           *utils.TemporarySSHKey
-	publicIP         string
-	privateIP        string
-	sshPublicKeyFile string
+	instance           *ec2typesv2.Instance
+	instanceID         string
+	sshKey             *utils.TemporarySSHKey
+	publicIP           string
+	privateIP          string
+	ipv6Address        string
+	networkInterfaceID string
+	sshPublicKeyFile   string
 }
 
 var operatingSystems = []string{
@@ -660,12 +662,22 @@ func (a *AWSRunner) createAWSInstance(img utils.InternalAWSImage) (*awsInstance,
 	if instance.PrivateIpAddress == nil {
 		return nil, fmt.Errorf("missing private ip address for instance id : %s", *instance.InstanceId)
 	}
-	return &awsInstance{
+	ai := &awsInstance{
 		instanceID: *instance.InstanceId,
 		instance:   instance,
 		publicIP:   *instance.PublicIpAddress,
 		privateIP:  *instance.PrivateIpAddress,
-	}, nil
+	}
+	if a.deployer.IPFamily != "" && a.deployer.IPFamily != "ipv4" {
+		if len(instance.NetworkInterfaces) > 0 {
+			ni := instance.NetworkInterfaces[0]
+			ai.networkInterfaceID = awsv2.ToString(ni.NetworkInterfaceId)
+			if len(ni.Ipv6Addresses) > 0 {
+				ai.ipv6Address = awsv2.ToString(ni.Ipv6Addresses[0].Ipv6Address)
+			}
+		}
+	}
+	return ai, nil
 }
 
 func (a *AWSRunner) dumpUserData(filename, content string) error {

--- a/kubetest2-ec2/pkg/deployer/runner.go
+++ b/kubetest2-ec2/pkg/deployer/runner.go
@@ -573,6 +573,12 @@ func (a *AWSRunner) getUserData(dataFile string, version string, controlPlane bo
 			data = strings.ReplaceAll(data, "{{ENABLE_DRA_NVIDIA}}", "false")
 		}
 
+		if a.deployer.IPFamily == "dual" {
+			data = strings.ReplaceAll(data, "{{EXTERNAL_CCM_DAEMONSET_URL}}", "https://raw.githubusercontent.com/nrb/cloud-provider-aws/refs/heads/dual-stack-example/examples/existing-cluster-dual-stack/base") // TODO(nrb): Update this once https://github.com/kubernetes/cloud-provider-aws/pull/1356 merges
+		} else {
+			data = strings.ReplaceAll(data, "{{EXTERNAL_CCM_DAEMONSET_URL}}", "https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/master/examples/existing-cluster/base")
+		}
+
 		return data
 	})
 	if err != nil {

--- a/kubetest2-ec2/pkg/deployer/runner.go
+++ b/kubetest2-ec2/pkg/deployer/runner.go
@@ -59,6 +59,7 @@ type AWSRunner struct {
 	certificateKey     string
 	controlPlaneIP     string
 	subnetID           string
+	vpcID              string
 }
 
 type awsInstance struct {
@@ -393,7 +394,7 @@ func (a *AWSRunner) prepareAWSImages() ([]utils.InternalAWSImage, error) {
 		return nil, fmt.Errorf("unable to load controlplane user data %s : %w", a.deployer.UserDataFile, err)
 	}
 	if len(userControlPlane) > 16384 { // 16KB
-		return nil, fmt.Errorf("worker user data is too large, must be less than 16384 bytes, is %d\n\n%s", len(userControlPlane), userControlPlane)
+		return nil, fmt.Errorf("control plane user data is too large, must be less than 16384 bytes, is %d\n\n%s", len(userControlPlane), userControlPlane)
 	}
 
 	userDataWorkerNode, err := a.getUserData(a.deployer.WorkerUserDataFile, version, false)
@@ -482,6 +483,12 @@ func (a *AWSRunner) getUserData(dataFile string, version string, controlPlane bo
 		data = strings.ReplaceAll(data, "{{EXTERNAL_CLOUD_PROVIDER}}", provider)
 		data = strings.ReplaceAll(data, "{{RUNTIME_CONFIG}}", a.deployer.RuntimeConfig)
 		data = strings.ReplaceAll(data, "{{FEATURE_GATES}}", a.deployer.FeatureGates)
+		if a.deployer.IPFamily == "dual" {
+			data = strings.ReplaceAll(data, "{{SERVICE_CIDR}}", "10.96.0.0/12,fd00:10:96::/112")
+			data = strings.ReplaceAll(data, "{{POD_CIDR}}", "192.168.0.0/16,fd00:10:244::/56")
+		} else {
+			data = strings.ReplaceAll(data, "{{SERVICE_CIDR}}", "10.96.0.0/12")
+		}
 		return data
 	})
 	if err != nil {
@@ -597,10 +604,15 @@ func (a *AWSRunner) createAWSInstance(img utils.InternalAWSImage) (*awsInstance,
 
 	if a.subnetID == "" {
 		var err error
-		var vpcID string
-		a.subnetID, vpcID, err = utils.PickSubnetID(a.ec2Service)
+		a.subnetID, a.vpcID, err = utils.PickSubnetID(a.ec2Service)
 		if err != nil {
-			return nil, fmt.Errorf("picking subnet: %w in vpc (%s)", err, vpcID)
+			return nil, fmt.Errorf("picking subnet: %w in vpc (%s)", err, a.vpcID)
+		}
+	}
+
+	if a.deployer.IPFamily != "" && a.deployer.IPFamily != "ipv4" {
+		if _, err := utils.EnsureIPv6(context.TODO(), a.ec2Service, a.vpcID, a.subnetID); err != nil {
+			return nil, fmt.Errorf("ensuring IPv6 on subnet %s: %w", a.subnetID, err)
 		}
 	}
 
@@ -611,7 +623,8 @@ func (a *AWSRunner) createAWSInstance(img utils.InternalAWSImage) (*awsInstance,
 		a.deployer.ClusterID,
 		a.controlPlaneIP,
 		img,
-		a.subnetID)
+		a.subnetID,
+		a.deployer.IPFamily)
 	if err != nil {
 		return nil, fmt.Errorf("unable to launch instance : %w", err)
 	}

--- a/kubetest2-ec2/pkg/deployer/runner.go
+++ b/kubetest2-ec2/pkg/deployer/runner.go
@@ -393,16 +393,30 @@ func (a *AWSRunner) prepareAWSImages() ([]utils.InternalAWSImage, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to load controlplane user data %s : %w", a.deployer.UserDataFile, err)
 	}
-	if len(userControlPlane) > 16384 { // 16KB
-		return nil, fmt.Errorf("control plane user data is too large, must be less than 16384 bytes, is %d\n\n%s", len(userControlPlane), userControlPlane)
+	if err := a.dumpUserData("userdata-control-plane.yaml", userControlPlane); err != nil {
+		klog.Warningf("failed to write control plane userdata artifact: %v", err)
+	}
+	compressedCP, err := utils.GzipBytes([]byte(userControlPlane))
+	if err != nil {
+		return nil, fmt.Errorf("compressing control plane userdata for size check: %w", err)
+	}
+	if len(compressedCP) > 16384 {
+		return nil, fmt.Errorf("control plane user data is too large after compression (%d bytes); see userdata-control-plane.yaml in artifacts for content", len(compressedCP))
 	}
 
 	userDataWorkerNode, err := a.getUserData(a.deployer.WorkerUserDataFile, version, false)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load worker user data %s : %w", a.deployer.WorkerUserDataFile, err)
 	}
-	if len(userDataWorkerNode) > 16384 { // 16KB
-		return nil, fmt.Errorf("worker user data is too large, must be less than 16384 bytes, is %d\n\n%s", len(userDataWorkerNode), userDataWorkerNode)
+	if err := a.dumpUserData("userdata-worker.yaml", userDataWorkerNode); err != nil {
+		klog.Warningf("failed to write worker userdata artifact: %v", err)
+	}
+	compressedWorker, err := utils.GzipBytes([]byte(userDataWorkerNode))
+	if err != nil {
+		return nil, fmt.Errorf("compressing worker userdata for size check: %w", err)
+	}
+	if len(compressedWorker) > 16384 {
+		return nil, fmt.Errorf("worker user data is too large after compression (%d bytes); see userdata-worker.yaml in artifacts for content", len(compressedWorker))
 	}
 
 	klog.Infof("using %s for control plane image", a.deployer.Image)
@@ -650,6 +664,14 @@ func (a *AWSRunner) createAWSInstance(img utils.InternalAWSImage) (*awsInstance,
 		publicIP:   *instance.PublicIpAddress,
 		privateIP:  *instance.PrivateIpAddress,
 	}, nil
+}
+
+func (a *AWSRunner) dumpUserData(filename, content string) error {
+	dir := a.deployer.logsDir
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, filename), []byte(content), 0644)
 }
 
 // assignNewSSHKey generates a new SSH key-pair and assigns it to the EC2 instance using EC2-instance connect. It then

--- a/kubetest2-ec2/pkg/deployer/runner.go
+++ b/kubetest2-ec2/pkg/deployer/runner.go
@@ -526,6 +526,7 @@ func (a *AWSRunner) getUserData(dataFile string, version string, controlPlane bo
 		data = strings.ReplaceAll(data, "{{STAGING_VERSION}}", version)
 		data = strings.ReplaceAll(data, "{{KUBEADM_TOKEN}}", a.token)
 		data = strings.ReplaceAll(data, "{{KUBEADM_CERTIFICATE_KEY}}", a.certificateKey)
+		data = strings.ReplaceAll(data, "{{IP_FAMILY}}", a.deployer.IPFamily)
 		return data
 	})
 	if err != nil {

--- a/kubetest2-ec2/pkg/deployer/runner.go
+++ b/kubetest2-ec2/pkg/deployer/runner.go
@@ -498,8 +498,8 @@ func (a *AWSRunner) getUserData(dataFile string, version string, controlPlane bo
 		data = strings.ReplaceAll(data, "{{RUNTIME_CONFIG}}", a.deployer.RuntimeConfig)
 		data = strings.ReplaceAll(data, "{{FEATURE_GATES}}", a.deployer.FeatureGates)
 		if a.deployer.IPFamily == "dual" {
-			data = strings.ReplaceAll(data, "{{SERVICE_CIDR}}", "10.96.0.0/12,fd00:10:96::/112")
-			data = strings.ReplaceAll(data, "{{POD_CIDR}}", "192.168.0.0/16,fd00:10:244::/56")
+			data = strings.ReplaceAll(data, "{{SERVICE_CIDR}}", "fd00:10:96::/112,10.96.0.0/12")
+			// {{POD_CIDR}} left for run-kubeadm.sh to resolve from IMDS at boot
 		} else {
 			data = strings.ReplaceAll(data, "{{SERVICE_CIDR}}", "10.96.0.0/12")
 		}
@@ -568,6 +568,7 @@ func (a *AWSRunner) getUserData(dataFile string, version string, controlPlane bo
 		data = strings.ReplaceAll(data, "{{FEATURE_GATES}}", a.deployer.FeatureGates)
 		data = strings.ReplaceAll(data, "{{EXTERNAL_CLOUD_PROVIDER}}", provider)
 		data = strings.ReplaceAll(data, "{{EXTERNAL_CLOUD_PROVIDER_IMAGE}}", a.deployer.ExternalCloudProviderImage)
+		data = strings.ReplaceAll(data, "{{IP_FAMILY}}", a.deployer.IPFamily)
 
 		if loadBalancer {
 			data = strings.ReplaceAll(data, "{{EXTERNAL_LOAD_BALANCER}}", "true")

--- a/kubetest2-ec2/pkg/deployer/utils/ec2.go
+++ b/kubetest2-ec2/pkg/deployer/utils/ec2.go
@@ -98,7 +98,11 @@ func LaunchNewInstance(ec2Service *ec2v2.Client, iamService *iamv2.Client,
 	}
 	if len(img.UserData) > 0 {
 		data := strings.ReplaceAll(img.UserData, "{{KUBEADM_CONTROL_PLANE_IP}}", controlPlaneIP)
-		input.UserData = awsv2.String(base64.StdEncoding.EncodeToString([]byte(data)))
+		compressed, err := GzipBytes([]byte(data))
+		if err != nil {
+			return nil, fmt.Errorf("compressing userdata: %w", err)
+		}
+		input.UserData = awsv2.String(base64.StdEncoding.EncodeToString(compressed))
 	}
 	if img.InstanceProfile != "" {
 		arn, err := GetInstanceProfileArn(iamService, img.InstanceProfile)

--- a/kubetest2-ec2/pkg/deployer/utils/ec2.go
+++ b/kubetest2-ec2/pkg/deployer/utils/ec2.go
@@ -316,13 +316,6 @@ func EnsureIPv6(ctx context.Context, svc *ec2v2.Client, vpcID, subnetID string) 
 		}
 	}
 
-	if _, err := svc.ModifySubnetAttribute(ctx, &ec2v2.ModifySubnetAttributeInput{
-		SubnetId:                    awsv2.String(subnetID),
-		AssignIpv6AddressOnCreation: &ec2typesv2.AttributeBooleanValue{Value: awsv2.Bool(true)},
-	}); err != nil {
-		return "", fmt.Errorf("enable IPv6 auto-assignment on subnet %s: %w", subnetID, err)
-	}
-
 	// 4. Add ::/0 route via the IGW to the subnet's route table (if not already present)
 	igwOut, err := svc.DescribeInternetGateways(ctx, &ec2v2.DescribeInternetGatewaysInput{
 		Filters: []ec2typesv2.Filter{
@@ -431,22 +424,6 @@ func TeardownIPv6Subnet(ctx context.Context, svc *ec2v2.Client, subnetID string)
 		return nil // already deleted
 	}
 
-	// AWS's API needs a *bool, not just a bool.
-	falseVal := false
-
-	// Remove the IPv6 auto-assignment before disassociating the IPv6 CIDR.
-	modifyInput := &ec2v2.ModifySubnetAttributeInput{
-		SubnetId: &subnetID,
-		AssignIpv6AddressOnCreation: &ec2typesv2.AttributeBooleanValue{
-			Value: &falseVal,
-		},
-	}
-
-	_, err = svc.ModifySubnetAttribute(ctx, modifyInput)
-	if err != nil {
-		return fmt.Errorf("could not disable ipv6 creation on assignment for subnet %s: %w", subnetID, err)
-	}
-
 	err = waitForIPv6Association(ctx, svc, func(ctx context.Context, svc *ec2v2.Client) error {
 		for _, a := range out.Subnets[0].Ipv6CidrBlockAssociationSet {
 			if a.Ipv6CidrBlockState.State == ec2typesv2.SubnetCidrBlockStateCodeAssociated {
@@ -471,4 +448,13 @@ func TeardownIPv6Subnet(ctx context.Context, svc *ec2v2.Client, subnetID string)
 	}
 
 	return nil
+}
+
+// UnassignIPv6FromInstance removes a specific IPv6 address from an instance's network interface.
+func UnassignIPv6FromInstance(ctx context.Context, svc *ec2v2.Client, networkInterfaceID, ipv6Addr string) error {
+	_, err := svc.UnassignIpv6Addresses(ctx, &ec2v2.UnassignIpv6AddressesInput{
+		NetworkInterfaceId: awsv2.String(networkInterfaceID),
+		Ipv6Addresses:      []string{ipv6Addr},
+	})
+	return err
 }

--- a/kubetest2-ec2/pkg/deployer/utils/ec2.go
+++ b/kubetest2-ec2/pkg/deployer/utils/ec2.go
@@ -3,14 +3,19 @@ package utils
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"hash/fnv"
+	"math/rand"
+	"net"
+	"strings"
+	"time"
+
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
 	ec2v2 "github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2typesv2 "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	iamv2 "github.com/aws/aws-sdk-go-v2/service/iam"
-	"math/rand"
-	"strings"
-	"time"
+	"github.com/aws/smithy-go"
 
 	"k8s.io/klog/v2"
 
@@ -28,7 +33,7 @@ type InternalAWSImage struct {
 }
 
 func LaunchNewInstance(ec2Service *ec2v2.Client, iamService *iamv2.Client,
-	clusterID string, controlPlaneIP string, img InternalAWSImage, subnetID string) (*ec2typesv2.Instance, error) {
+	clusterID string, controlPlaneIP string, img InternalAWSImage, subnetID string, ipFamily string) (*ec2typesv2.Instance, error) {
 	images, err := ec2Service.DescribeImages(context.TODO(), &ec2v2.DescribeImagesInput{ImageIds: []string{img.AmiID}})
 	if err != nil {
 		return nil, fmt.Errorf("describing images: %w", err)
@@ -45,11 +50,17 @@ func LaunchNewInstance(ec2Service *ec2v2.Client, iamService *iamv2.Client,
 			HttpTokens:   "required",
 		},
 		NetworkInterfaces: []ec2typesv2.InstanceNetworkInterfaceSpecification{
-			{
-				SubnetId:                 awsv2.String(subnetID),
-				AssociatePublicIpAddress: awsv2.Bool(true),
-				DeviceIndex:              awsv2.Int32(0),
-			},
+			func() ec2typesv2.InstanceNetworkInterfaceSpecification {
+				iface := ec2typesv2.InstanceNetworkInterfaceSpecification{
+					SubnetId:                 awsv2.String(subnetID),
+					AssociatePublicIpAddress: awsv2.Bool(true),
+					DeviceIndex:              awsv2.Int32(0),
+				}
+				if ipFamily != "" && ipFamily != "ipv4" {
+					iface.Ipv6AddressCount = awsv2.Int32(1)
+				}
+				return iface
+			}(),
 		},
 		TagSpecifications: []ec2typesv2.TagSpecification{
 			{
@@ -197,4 +208,263 @@ func getSubnetIDs(svc *ec2v2.Client, vpcID string) ([]string, error) {
 	}
 
 	return subnetIDs, nil
+}
+
+// EnsureIPv6 associates an Amazon-provided IPv6 CIDR with the given VPC (idempotent),
+// then associates a /64 block with the subnet and enables IPv6 auto-assignment.
+// It also adds a ::/0 route via the VPC's Internet Gateway to the subnet's route table.
+func EnsureIPv6(ctx context.Context, svc *ec2v2.Client, vpcID, subnetID string) (string, error) {
+	// 1. Check if VPC already has an IPv6 CIDR
+	vpcsOut, err := svc.DescribeVpcs(ctx, &ec2v2.DescribeVpcsInput{VpcIds: []string{vpcID}})
+	if err != nil {
+		return "", fmt.Errorf("describe VPC %s: %w", vpcID, err)
+	}
+	var vpcIPv6CIDR string
+	for _, a := range vpcsOut.Vpcs[0].Ipv6CidrBlockAssociationSet {
+		if a.Ipv6CidrBlockState.State == ec2typesv2.VpcCidrBlockStateCodeAssociated {
+			vpcIPv6CIDR = awsv2.ToString(a.Ipv6CidrBlock)
+			break
+		}
+	}
+
+	// 2. If not, request one from Amazon's pool and wait for it to become active
+	if vpcIPv6CIDR == "" {
+		out, err := svc.AssociateVpcCidrBlock(ctx, &ec2v2.AssociateVpcCidrBlockInput{
+			VpcId:                       awsv2.String(vpcID),
+			AmazonProvidedIpv6CidrBlock: awsv2.Bool(true),
+		})
+		if err != nil {
+			return "", fmt.Errorf("associate IPv6 CIDR with VPC %s: %w", vpcID, err)
+		}
+
+		assocID := awsv2.ToString(out.Ipv6CidrBlockAssociation.AssociationId)
+
+		err = waitForIPv6Association(ctx, svc, func(ctx context.Context, svc *ec2v2.Client) error {
+			klog.Infof("checking VPC %s for IPv6 association", vpcID)
+			out, err := svc.DescribeVpcs(ctx, &ec2v2.DescribeVpcsInput{VpcIds: []string{vpcID}})
+			if err != nil {
+				return err
+			}
+			for _, a := range out.Vpcs[0].Ipv6CidrBlockAssociationSet {
+				if a.Ipv6CidrBlock == nil {
+					return fmt.Errorf("IPv6 CIDR not yet associated with VPC")
+				}
+				if awsv2.ToString(a.AssociationId) == assocID {
+					if a.Ipv6CidrBlockState.State == ec2typesv2.VpcCidrBlockStateCodeAssociated {
+						klog.Infof("found vpcIPv6CIDR: %s", a.Ipv6CidrBlock)
+						vpcIPv6CIDR = awsv2.ToString(a.Ipv6CidrBlock)
+						return nil
+					}
+				}
+			}
+			return fmt.Errorf("timed out waiting for VPC %s IPv6 CIDR association %s", vpcID, assocID)
+		})
+
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// 3. Carve a /64 for the subnet (if not already present) and enable auto-assignment
+	var hasIPv6 bool
+	var subnetOut *ec2v2.DescribeSubnetsOutput
+	checkSubnetAssociated := func(ctx context.Context, svc *ec2v2.Client) error {
+		klog.Infof("checking subnet %s for IPv6 CIDR", subnetID)
+		subnetOut, err = svc.DescribeSubnets(ctx, &ec2v2.DescribeSubnetsInput{SubnetIds: []string{subnetID}})
+		if err != nil {
+			return fmt.Errorf("describe subnet %s: %w", subnetID, err)
+		}
+		klog.Infof("subnetOut items: %d", len(subnetOut.Subnets))
+		klog.Infof("association set items: %d", len(subnetOut.Subnets[0].Ipv6CidrBlockAssociationSet))
+		hasIPv6 = false
+		for _, a := range subnetOut.Subnets[0].Ipv6CidrBlockAssociationSet {
+			klog.Infof("found the subnet")
+			if a.Ipv6CidrBlockState.State == ec2typesv2.SubnetCidrBlockStateCodeAssociated {
+				klog.Infof("CIDR associated")
+				hasIPv6 = true
+				break
+			}
+		}
+		return nil
+	}
+
+	// Check the subnet's association initially to determine if it has IPv6 yet.
+	checkSubnetAssociated(ctx, svc)
+	klog.Infof("subnetOut items after check: %d", len(subnetOut.Subnets))
+
+	if !hasIPv6 {
+		subnetIPv6CIDR, err := ipv6SubnetCIDR(
+			awsv2.ToString(subnetOut.Subnets[0].CidrBlock),
+			vpcIPv6CIDR,
+		)
+		if err != nil {
+			return "", fmt.Errorf("derive /64 for subnet %s: %w", subnetID, err)
+		}
+		if _, err := svc.AssociateSubnetCidrBlock(ctx, &ec2v2.AssociateSubnetCidrBlockInput{
+			SubnetId:      awsv2.String(subnetID),
+			Ipv6CidrBlock: awsv2.String(subnetIPv6CIDR),
+		}); err != nil {
+			return "", fmt.Errorf("associate IPv6 CIDR %s with subnet %s: %w", subnetIPv6CIDR, subnetID, err)
+		}
+		err = waitForIPv6Association(ctx, svc, checkSubnetAssociated)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	if _, err := svc.ModifySubnetAttribute(ctx, &ec2v2.ModifySubnetAttributeInput{
+		SubnetId:                    awsv2.String(subnetID),
+		AssignIpv6AddressOnCreation: &ec2typesv2.AttributeBooleanValue{Value: awsv2.Bool(true)},
+	}); err != nil {
+		return "", fmt.Errorf("enable IPv6 auto-assignment on subnet %s: %w", subnetID, err)
+	}
+
+	// 4. Add ::/0 route via the IGW to the subnet's route table (if not already present)
+	igwOut, err := svc.DescribeInternetGateways(ctx, &ec2v2.DescribeInternetGatewaysInput{
+		Filters: []ec2typesv2.Filter{
+			{Name: awsv2.String("attachment.vpc-id"), Values: []string{vpcID}},
+		},
+	})
+	if err != nil || len(igwOut.InternetGateways) == 0 {
+		return "", fmt.Errorf("find internet gateway for VPC %s: %w", vpcID, err)
+	}
+	igwID := awsv2.ToString(igwOut.InternetGateways[0].InternetGatewayId)
+
+	// Prefer the route table explicitly associated with the subnet; fall back to the VPC main table.
+	rtOut, err := svc.DescribeRouteTables(ctx, &ec2v2.DescribeRouteTablesInput{
+		Filters: []ec2typesv2.Filter{
+			{Name: awsv2.String("association.subnet-id"), Values: []string{subnetID}},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("describe route tables for subnet %s: %w", subnetID, err)
+	}
+	if len(rtOut.RouteTables) == 0 {
+		rtOut, err = svc.DescribeRouteTables(ctx, &ec2v2.DescribeRouteTablesInput{
+			Filters: []ec2typesv2.Filter{
+				{Name: awsv2.String("vpc-id"), Values: []string{vpcID}},
+				{Name: awsv2.String("association.main"), Values: []string{"true"}},
+			},
+		})
+		if err != nil || len(rtOut.RouteTables) == 0 {
+			return "", fmt.Errorf("find main route table for VPC %s: %w", vpcID, err)
+		}
+	}
+	rtID := awsv2.ToString(rtOut.RouteTables[0].RouteTableId)
+	hasIPv6Route := false
+	for _, r := range rtOut.RouteTables[0].Routes {
+		if awsv2.ToString(r.DestinationIpv6CidrBlock) == "::/0" {
+			hasIPv6Route = true
+			break
+		}
+	}
+	if !hasIPv6Route {
+		if _, err := svc.CreateRoute(ctx, &ec2v2.CreateRouteInput{
+			RouteTableId:             awsv2.String(rtID),
+			DestinationIpv6CidrBlock: awsv2.String("::/0"),
+			GatewayId:                awsv2.String(igwID),
+		}); err != nil {
+			return "", fmt.Errorf("create ::/0 route in route table %s: %w", rtID, err)
+		}
+	}
+
+	return vpcIPv6CIDR, nil
+}
+
+// waitFunc defines a function that will execute an AWS Client call and return an error.
+// It will be executed in a loop until a) it returns `nil` or b) timeout is passed.
+type waitFunc func(ctx context.Context, svc *ec2v2.Client) error
+
+func waitForIPv6Association(ctx context.Context, svc *ec2v2.Client, waiterFunc waitFunc) error {
+	var err error
+	var i int
+
+	for i = 0; i < 30; i++ {
+		err = waiterFunc(ctx, svc)
+		if err == nil {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
+
+	if i == 30 {
+		err = fmt.Errorf("timed out waiting for condition")
+	}
+
+	return err
+}
+
+// ipv6SubnetCIDR derives a /64 prefix for the given subnet from the VPC's /56 IPv6 block.
+// The index byte is an FNV hash of the subnet's IPv4 CIDR string. Collisions are
+// theoretically possible but negligible for AWS VPCs (≤200 subnets per VPC).
+func ipv6SubnetCIDR(subnetIPv4CIDR, vpcIPv6CIDR string) (string, error) {
+	h := fnv.New32a()
+	h.Write([]byte(subnetIPv4CIDR))
+
+	klog.Infof("Trying to use net.ParseCIDR")
+
+	_, vpcIPv6Net, err := net.ParseCIDR(vpcIPv6CIDR)
+	if err != nil {
+		return "", fmt.Errorf("parse VPC IPv6 CIDR %s: %w", vpcIPv6CIDR, err)
+	}
+	ip6 := make(net.IP, 16)
+	copy(ip6, vpcIPv6Net.IP)
+	ip6[7] = byte(h.Sum32())
+	for i := 8; i < 16; i++ {
+		ip6[i] = 0
+	}
+	return fmt.Sprintf("%s/64", ip6), nil
+}
+
+// TeardownIPv6Subnet disassociates all IPv6 /64 CIDR blocks from the subnet.
+// The subnet deletion itself and the VPC-level /56 are handled separately.
+func TeardownIPv6Subnet(ctx context.Context, svc *ec2v2.Client, subnetID string) error {
+	out, err := svc.DescribeSubnets(ctx, &ec2v2.DescribeSubnetsInput{SubnetIds: []string{subnetID}})
+	if err != nil {
+		return fmt.Errorf("describe subnet %s: %w", subnetID, err)
+	}
+	if len(out.Subnets) == 0 {
+		return nil // already deleted
+	}
+
+	// AWS's API needs a *bool, not just a bool.
+	falseVal := false
+
+	// Remove the IPv6 auto-assignment before disassociating the IPv6 CIDR.
+	modifyInput := &ec2v2.ModifySubnetAttributeInput{
+		SubnetId: &subnetID,
+		AssignIpv6AddressOnCreation: &ec2typesv2.AttributeBooleanValue{
+			Value: &falseVal,
+		},
+	}
+
+	_, err = svc.ModifySubnetAttribute(ctx, modifyInput)
+	if err != nil {
+		return fmt.Errorf("could not disable ipv6 creation on assignment for subnet %s: %w", subnetID, err)
+	}
+
+	err = waitForIPv6Association(ctx, svc, func(ctx context.Context, svc *ec2v2.Client) error {
+		for _, a := range out.Subnets[0].Ipv6CidrBlockAssociationSet {
+			if a.Ipv6CidrBlockState.State == ec2typesv2.SubnetCidrBlockStateCodeAssociated {
+				if _, err := svc.DisassociateSubnetCidrBlock(ctx, &ec2v2.DisassociateSubnetCidrBlockInput{
+					AssociationId: a.AssociationId,
+				}); err != nil {
+					var smithyErr smithy.APIError
+					// resource may be in use, keep trying if so.
+					if errors.As(err, &smithyErr) && smithyErr.ErrorCode() == "400" {
+						continue
+					}
+				}
+				// no error
+				return nil
+			}
+		}
+		return fmt.Errorf("disassociate IPv6 CIDR from subnet %s: %w", subnetID, err)
+	})
+
+	if err != nil {
+		return fmt.Errorf("timed out waiting for IPv6 CIDR to disassoiate from subnet %s: %w", subnetID, err)
+	}
+
+	return nil
 }

--- a/kubetest2-ec2/pkg/deployer/utils/userdata.go
+++ b/kubetest2-ec2/pkg/deployer/utils/userdata.go
@@ -29,6 +29,22 @@ import (
 	"sigs.k8s.io/provider-aws-test-infra/kubetest2-ec2/config"
 )
 
+// GzipBytes compresses data using gzip at best-compression level.
+func GzipBytes(data []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	gz, err := gzip.NewWriterLevel(&buf, flate.BestCompression)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := gz.Write(data); err != nil {
+		return nil, err
+	}
+	if err := gz.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
 func gzipAndBase64Encode(fileBytes []byte) (string, error) {
 	var buffer bytes.Buffer
 	gz, err := gzip.NewWriterLevel(&buffer, flate.BestCompression)


### PR DESCRIPTION
Extends the kubetest2-ec2 deployer with a new --ip-family flag (ipv4/ipv6/dual). When set to dual or ipv6, the deployer enables IPv6 on the default VPC at runtime: associates an Amazon-provided /56 CIDR with the VPC, carves a deterministic /64 per subnet (FNV hash of the IPv4 CIDR), enables IPv6 auto-assignment, and adds a ::/0 route via the IGW. Instances receive an IPv6 address on the primary ENI. The kubelet node-ip is set to the comma-joined IPv4,IPv6 pair via run-kubeadm.sh. Kubeadm is configured with dual-stack service and pod CIDRs when --ip-family=dual. IPv6 subnet CIDRs are disassociated on Down().