### PR TITLE
Bump Kubernetes on (04/03/2026)

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e_node/remote/utils.go
+++ b/vendor/k8s.io/kubernetes/test/e2e_node/remote/utils.go
@@ -28,7 +28,7 @@ import (
 // utils.go contains functions used across test suites.
 
 const (
-	cniVersion       = "v1.9.0"
+	cniVersion       = "v1.9.1"
 	cniDirectory     = "cni/bin" // The CNI tarball places binaries under directory under "cni/bin".
 	cniConfDirectory = "cni/net.d"
 


### PR DESCRIPTION
PR filed with output of running hack/bump-k8s.sh on Date: 04/03/2026