### PR TITLE
kubetest2-ec2: add --ip-family flag (ipv4/ipv6/dual)

### DIFF
--- a/kubetest2-ec2/pkg/deployer/deployer.go
+++ b/kubetest2-ec2/pkg/deployer/deployer.go
@@ -145,6 +145,7 @@ type deployer struct {
 	SSHUser            string `flag:"ssh-user" desc:"The SSH user to use for SSH access to instances"`
 	SSHEnv             string `flag:"ssh-env" desc:"Use predefined ssh options for environment."`
 	NumNodes           int    `flag:"num-nodes" desc:"Number of nodes in the cluster."`
+	IPFamily           string `flag:"ip-family" desc:"IP family for cluster networking: ipv4 (default), ipv6, or dual. When ipv6 or dual is set, instances are launched with an IPv6 address and only IPv6-enabled subnets are eligible. Configuring kubeadm/kubelet for dual-stack remains the caller's responsibility via user-data."`
 
 	runner  *AWSRunner
 	logsDir string

--- a/kubetest2-ec2/pkg/deployer/runner.go
+++ b/kubetest2-ec2/pkg/deployer/runner.go
@@ -598,7 +598,7 @@ func (a *AWSRunner) createAWSInstance(img utils.InternalAWSImage) (*awsInstance,
 	if a.subnetID == "" {
 		var err error
 		var vpcID string
-		a.subnetID, vpcID, err = utils.PickSubnetID(a.ec2Service)
+		a.subnetID, vpcID, err = utils.PickSubnetID(a.ec2Service, a.deployer.IPFamily)
 		if err != nil {
 			return nil, fmt.Errorf("picking subnet: %w in vpc (%s)", err, vpcID)
 		}
@@ -611,7 +611,8 @@ func (a *AWSRunner) createAWSInstance(img utils.InternalAWSImage) (*awsInstance,
 		a.deployer.ClusterID,
 		a.controlPlaneIP,
 		img,
-		a.subnetID)
+		a.subnetID,
+		a.deployer.IPFamily)
 	if err != nil {
 		return nil, fmt.Errorf("unable to launch instance : %w", err)
 	}

--- a/kubetest2-ec2/pkg/deployer/utils/ec2.go
+++ b/kubetest2-ec2/pkg/deployer/utils/ec2.go
@@ -28,10 +28,19 @@ type InternalAWSImage struct {
 }
 
 func LaunchNewInstance(ec2Service *ec2v2.Client, iamService *iamv2.Client,
-	clusterID string, controlPlaneIP string, img InternalAWSImage, subnetID string) (*ec2typesv2.Instance, error) {
+	clusterID string, controlPlaneIP string, img InternalAWSImage, subnetID string, ipFamily string) (*ec2typesv2.Instance, error) {
 	images, err := ec2Service.DescribeImages(context.TODO(), &ec2v2.DescribeImagesInput{ImageIds: []string{img.AmiID}})
 	if err != nil {
 		return nil, fmt.Errorf("describing images: %w", err)
+	}
+
+	netIface := ec2typesv2.InstanceNetworkInterfaceSpecification{
+		SubnetId:                 awsv2.String(subnetID),
+		AssociatePublicIpAddress: awsv2.Bool(true),
+		DeviceIndex:              awsv2.Int32(0),
+	}
+	if ipFamily == "ipv6" || ipFamily == "dual" {
+		netIface.Ipv6AddressCount = awsv2.Int32(1)
 	}
 
 	name := clusterID + uuid.New().String()[:8]
@@ -44,13 +53,7 @@ func LaunchNewInstance(ec2Service *ec2v2.Client, iamService *iamv2.Client,
 			HttpEndpoint: "enabled",
 			HttpTokens:   "required",
 		},
-		NetworkInterfaces: []ec2typesv2.InstanceNetworkInterfaceSpecification{
-			{
-				SubnetId:                 awsv2.String(subnetID),
-				AssociatePublicIpAddress: awsv2.Bool(true),
-				DeviceIndex:              awsv2.Int32(0),
-			},
-		},
+		NetworkInterfaces: []ec2typesv2.InstanceNetworkInterfaceSpecification{netIface},
 		TagSpecifications: []ec2typesv2.TagSpecification{
 			{
 				ResourceType: ec2typesv2.ResourceTypeInstance,
@@ -127,22 +130,30 @@ func WaitForInstanceToRun(ec2Service *ec2v2.Client, instance *ec2typesv2.Instanc
 	return instance
 }
 
-func PickSubnetID(svc *ec2v2.Client) (string, string, error) {
+func PickSubnetID(svc *ec2v2.Client, ipFamily string) (string, string, error) {
 	defaultVpcID, err := getDefaultVPC(svc)
 	if err != nil {
 		return "", "", fmt.Errorf("Failed to get default VPC: %v", err)
 	}
 	klog.Infof("Default VPC ID: %s\n", defaultVpcID)
 
-	// Get subnet IDs for the default VPC
-	subnetIDs, err := getSubnetIDs(svc, defaultVpcID)
+	// Get subnet IDs for the default VPC. When the caller asked for an IPv6
+	// or dual-stack cluster, restrict to subnets that already have an IPv6
+	// CIDR association — instance launch would otherwise fail with
+	// InvalidParameterValue: ipv6AddressCount cannot be specified on a subnet
+	// without IPv6 enabled.
+	requireIPv6 := ipFamily == "ipv6" || ipFamily == "dual"
+	subnetIDs, err := getSubnetIDs(svc, defaultVpcID, requireIPv6)
 	if err != nil {
 		return "", "", fmt.Errorf("Failed to get subnet IDs: %v", err)
 	}
 
 	// Print the results
-	klog.Infof("Subnet IDs: %v", subnetIDs)
+	klog.Infof("Subnet IDs (ipFamily=%q, requireIPv6=%v): %v", ipFamily, requireIPv6, subnetIDs)
 	if len(subnetIDs) == 0 {
+		if requireIPv6 {
+			return "", "", fmt.Errorf("No IPv6-enabled subnets found in the default VPC %s; enable an IPv6 CIDR on at least one subnet or run without --ip-family=%s", defaultVpcID, ipFamily)
+		}
 		return "", "", fmt.Errorf("No subnets found in the default VPC: %s", defaultVpcID)
 	}
 	randomSubnetID := subnetIDs[rand.Intn(len(subnetIDs))]
@@ -172,7 +183,7 @@ func getDefaultVPC(svc *ec2v2.Client) (string, error) {
 	return *result.Vpcs[0].VpcId, nil
 }
 
-func getSubnetIDs(svc *ec2v2.Client, vpcID string) ([]string, error) {
+func getSubnetIDs(svc *ec2v2.Client, vpcID string, requireIPv6 bool) ([]string, error) {
 	input := &ec2v2.DescribeSubnetsInput{
 		Filters: []ec2typesv2.Filter{
 			{
@@ -193,8 +204,23 @@ func getSubnetIDs(svc *ec2v2.Client, vpcID string) ([]string, error) {
 		if *subnet.AvailabilityZone == "us-east-1e" {
 			continue
 		}
+		if requireIPv6 && !hasIPv6CIDR(subnet) {
+			continue
+		}
 		subnetIDs = append(subnetIDs, *subnet.SubnetId)
 	}
 
 	return subnetIDs, nil
+}
+
+// hasIPv6CIDR returns true when the subnet has at least one associated IPv6
+// CIDR block that is in the associated state (i.e. usable by instances).
+func hasIPv6CIDR(subnet ec2typesv2.Subnet) bool {
+	for _, assoc := range subnet.Ipv6CidrBlockAssociationSet {
+		if assoc.Ipv6CidrBlockState != nil &&
+			assoc.Ipv6CidrBlockState.State == ec2typesv2.SubnetCidrBlockStateCodeAssociated {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary

Wires `--ip-family` end-to-end in the `kubetest2-ec2` deployer (`ipv4` | `ipv6` | `dual`). Today the presubmit [`pull-kubernetes-e2e-ec2-cloud-provider-dual-stack-quick`](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-ec2-cloud-provider-dual-stack-quick) (added in [kubernetes/test-infra#36625](https://github.com/kubernetes/test-infra/pull/36625) / commit [`7bb55ca651`](https://github.com/kubernetes/test-infra/commit/7bb55ca651)) calls:

```sh
kubetest2 ec2 --ip-family=dual ...
```

…but the deployer struct had no `IPFamily` field, so `gpflag.Parse(d)` (in `bindFlags`) rejects the flag at parse time:

```
unknown flag: --ip-family
```

The job is `optional: true`, so PRs have been merging while the presubmit silently failed for ~53 days. Last known failure: [pr 550 / build 2053260882053435392](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_provider-aws-test-infra/550/pull-kubernetes-e2e-ec2-cloud-provider-dual-stack-quick/2053260882053435392).

## What this changes

| File | Change |
|---|---|
| `kubetest2-ec2/pkg/deployer/deployer.go` | Add `IPFamily string` struct field with `flag:"ip-family"` tag. Empty == `ipv4` for backward compatibility. |
| `kubetest2-ec2/pkg/deployer/utils/ec2.go` — `LaunchNewInstance` | Accept `ipFamily`. When `"ipv6"` or `"dual"`, set `Ipv6AddressCount: 1` on the `InstanceNetworkInterfaceSpecification` so `RunInstances` allocates an IPv6 address on the primary ENI. |
| `kubetest2-ec2/pkg/deployer/utils/ec2.go` — `PickSubnetID` / `getSubnetIDs` | When an IPv6 family is requested, filter the default VPC's subnets to those with an associated (`state=associated`) IPv6 CIDR block. Without this filter `RunInstances` would 400 with `InvalidParameterValue: ipv6AddressCount cannot be specified on a subnet without IPv6 enabled`. |
| `kubetest2-ec2/pkg/deployer/runner.go` — `createAWSInstance` | Thread `a.deployer.IPFamily` to both helpers. |

New helper `hasIPv6CIDR(subnet)` walks `Subnet.Ipv6CidrBlockAssociationSet` and returns `true` when at least one association is in the `associated` state.

## What this intentionally does not do

Dual-stack **cluster networking** (kubeadm `--service-cidr=v4,v6`, kubelet `--node-ip=v4,v6`, pod CIDR, CNI choice) stays the caller's responsibility, driven by the existing `UserDataFile` / `WorkerUserDataFile` flags. This change is scoped to the deployer's VM provisioning — making nodes IPv6-capable so the test caller's user-data has something to configure. A follow-up can opinionate on the user-data side.

## Operational prerequisite

The default VPC in the test AWS account needs at least one subnet with an associated IPv6 CIDR block. If none exists, `PickSubnetID` now returns:

```
No IPv6-enabled subnets found in the default VPC vpc-XXXX; enable an IPv6 CIDR
on at least one subnet or run without --ip-family=dual
```

(rather than letting `RunInstances` fail with the generic InvalidParameterValue described above).

## Test plan

- [x] `cd kubetest2-ec2 && go build ./...` &mdash; exits 0.
- [x] `cd kubetest2-ec2 && go vet ./pkg/deployer/...` &mdash; no new findings. (Two pre-existing `%w`-in-`fmt.Sprintf` warnings in `pkg/deployer/utils/userdata.go:155,159` are unchanged; verified by stashing this diff and re-running vet on `upstream/main`.)
- [ ] CI: presubmit `pull-kubernetes-e2e-ec2-cloud-provider-dual-stack-quick` should now get past flag parsing and exercise `RunInstances` with `Ipv6AddressCount=1`; if the test account's default VPC has dual-stack subnets, expect the cluster to come up.
- [ ] Sanity: existing `--ip-family` unset / `=ipv4` lanes (every other ec2 presubmit/periodic) should be byte-identical &mdash; no new fields set on `InstanceNetworkInterfaceSpecification`, no extra subnet filter.

## Related

- Job definition: [`config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml:525`](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cloud-provider/aws/ec2-e2e.yaml#L525)
- Test-infra commit that added the presubmit (without deployer support): [`7bb55ca651`](https://github.com/kubernetes/test-infra/commit/7bb55ca651)