### PR TITLE
Migrate kubeadm configs from v1beta3 to v1beta4

### DIFF
--- a/kubetest2-ec2/config/al2023.sh
+++ b/kubetest2-ec2/config/al2023.sh
@@ -120,7 +120,7 @@ mkdir -p /var/log/containers/
 chmod -R a+rx /var/log/containers/
 
 cat << EOF > /etc/kubernetes/kubeadm-join.yaml
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: JoinConfiguration
 discovery:
   bootstrapToken:
@@ -131,19 +131,32 @@ nodeRegistration:
   criSocket: unix:///run/containerd/containerd.sock
   name: {{HOSTNAME_OVERRIDE}}
   kubeletExtraArgs:
-    feature-gates: {{FEATURE_GATES}}
-    node-labels: {{NODE_LABELS}}
-    cloud-provider: {{EXTERNAL_CLOUD_PROVIDER}}
-    provider-id: {{PROVIDER_ID}}
-    node-ip: {{NODE_IP}}
-    hostname-override: {{HOSTNAME_OVERRIDE}}
-    image-credential-provider-bin-dir: /etc/eks/image-credential-provider/
-    image-credential-provider-config: /etc/eks/image-credential-provider/config.json
-    resolv-conf: $RESOLVE_CONF
-    system-cgroups: /system.slice
-    runtime-cgroups: /runtime.slice
-    kubelet-cgroups: /runtime.slice
-    cgroup-root: /
+  - name: feature-gates
+    value: {{FEATURE_GATES}}
+  - name: node-labels
+    value: {{NODE_LABELS}}
+  - name: cloud-provider
+    value: {{EXTERNAL_CLOUD_PROVIDER}}
+  - name: provider-id
+    value: {{PROVIDER_ID}}
+  - name: node-ip
+    value: {{NODE_IP}}
+  - name: hostname-override
+    value: {{HOSTNAME_OVERRIDE}}
+  - name: image-credential-provider-bin-dir
+    value: /etc/eks/image-credential-provider/
+  - name: image-credential-provider-config
+    value: /etc/eks/image-credential-provider/config.json
+  - name: resolv-conf
+    value: $RESOLVE_CONF
+  - name: system-cgroups
+    value: /system.slice
+  - name: runtime-cgroups
+    value: /runtime.slice
+  - name: kubelet-cgroups
+    value: /runtime.slice
+  - name: cgroup-root
+    value: /
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration

--- a/kubetest2-ec2/config/kubeadm-init.yaml
+++ b/kubetest2-ec2/config/kubeadm-init.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: InitConfiguration
 bootstrapTokens:
 - groups:
@@ -8,35 +8,52 @@ nodeRegistration:
   criSocket: unix:///run/containerd/containerd.sock
   name: {{HOSTNAME_OVERRIDE}}
   kubeletExtraArgs:
-    feature-gates: {{FEATURE_GATES}}
-    cloud-provider: {{EXTERNAL_CLOUD_PROVIDER}}
-    provider-id: {{PROVIDER_ID}}
-    node-ip: {{NODE_IP}}
-    hostname-override: {{HOSTNAME_OVERRIDE}}
-    image-credential-provider-bin-dir: /usr/local/bin
-    image-credential-provider-config: /etc/kubernetes/credential-provider.yaml
-    resolv-conf: /run/systemd/resolve/resolv.conf
-    system-cgroups: /system.slice
-    runtime-cgroups: /runtime.slice
-    kubelet-cgroups: /runtime.slice
-    cgroup-root: /
+  - name: feature-gates
+    value: {{FEATURE_GATES}}
+  - name: cloud-provider
+    value: {{EXTERNAL_CLOUD_PROVIDER}}
+  - name: provider-id
+    value: {{PROVIDER_ID}}
+  - name: node-ip
+    value: {{NODE_IP}}
+  - name: hostname-override
+    value: {{HOSTNAME_OVERRIDE}}
+  - name: image-credential-provider-bin-dir
+    value: /usr/local/bin
+  - name: image-credential-provider-config
+    value: /etc/kubernetes/credential-provider.yaml
+  - name: resolv-conf
+    value: /run/systemd/resolve/resolv.conf
+  - name: system-cgroups
+    value: /system.slice
+  - name: runtime-cgroups
+    value: /runtime.slice
+  - name: kubelet-cgroups
+    value: /runtime.slice
+  - name: cgroup-root
+    value: /
 ---
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 kubernetesVersion: {{KUBERNETES_VERSION}}
 apiServer:
   extraArgs:
-    feature-gates: {{FEATURE_GATES}}
-    runtime-config: {{RUNTIME_CONFIG}}
+  - name: feature-gates
+    value: {{FEATURE_GATES}}
+  - name: runtime-config
+    value: {{RUNTIME_CONFIG}}
   certSANs:
   - {{EXTRA_SANS}}
 controllerManager:
   extraArgs:
-    cloud-provider: {{EXTERNAL_CLOUD_PROVIDER}}
-    feature-gates: {{FEATURE_GATES}}
+  - name: cloud-provider
+    value: {{EXTERNAL_CLOUD_PROVIDER}}
+  - name: feature-gates
+    value: {{FEATURE_GATES}}
 scheduler:
   extraArgs:
-    feature-gates: {{FEATURE_GATES}}
+  - name: feature-gates
+    value: {{FEATURE_GATES}}
 networking:
   podSubnet: {{POD_CIDR}}
 ---

--- a/kubetest2-ec2/config/kubeadm-join.yaml
+++ b/kubetest2-ec2/config/kubeadm-join.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: JoinConfiguration
 discovery:
   bootstrapToken:
@@ -9,18 +9,30 @@ nodeRegistration:
   criSocket: unix:///run/containerd/containerd.sock
   name: {{HOSTNAME_OVERRIDE}}
   kubeletExtraArgs:
-    feature-gates: {{FEATURE_GATES}}
-    cloud-provider: {{EXTERNAL_CLOUD_PROVIDER}}
-    provider-id: {{PROVIDER_ID}}
-    node-ip: {{NODE_IP}}
-    hostname-override: {{HOSTNAME_OVERRIDE}}
-    image-credential-provider-bin-dir: /usr/local/bin
-    image-credential-provider-config: /etc/kubernetes/credential-provider.yaml
-    resolv-conf: /run/systemd/resolve/resolv.conf
-    system-cgroups: /system.slice
-    runtime-cgroups: /runtime.slice
-    kubelet-cgroups: /runtime.slice
-    cgroup-root: /
+  - name: feature-gates
+    value: {{FEATURE_GATES}}
+  - name: cloud-provider
+    value: {{EXTERNAL_CLOUD_PROVIDER}}
+  - name: provider-id
+    value: {{PROVIDER_ID}}
+  - name: node-ip
+    value: {{NODE_IP}}
+  - name: hostname-override
+    value: {{HOSTNAME_OVERRIDE}}
+  - name: image-credential-provider-bin-dir
+    value: /usr/local/bin
+  - name: image-credential-provider-config
+    value: /etc/kubernetes/credential-provider.yaml
+  - name: resolv-conf
+    value: /run/systemd/resolve/resolv.conf
+  - name: system-cgroups
+    value: /system.slice
+  - name: runtime-cgroups
+    value: /runtime.slice
+  - name: kubelet-cgroups
+    value: /runtime.slice
+  - name: cgroup-root
+    value: /
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test
/kind bug

#### What this PR does / why we need it:

[kubernetes/kubernetes#136016](https://github.com/kubernetes/kubernetes/pull/136016) removed the kubeadm `v1beta3` API (landed at `v1.37.0-alpha.0.1250+`). kubetest2-ec2 still ships kubeadm `InitConfiguration`/`ClusterConfiguration`/`JoinConfiguration` on `kubeadm.k8s.io/v1beta3`, so the freshly-built `kubeadm init`/`join` now abort with:

```
error: your configuration file uses an old API spec: "kubeadm.k8s.io/v1beta3" (kind: "ClusterConfiguration"). Please use kubeadm v1.36 instead and run 'kubeadm config migrate' ...
```

The control plane never comes up (no `/etc/kubernetes/admin.conf`) and every `[Conformance]` test fails. This has turned the EC2 conformance jobs red on both architectures since 2026-06-01:

- `ci-kubernetes-ec2-conformance-latest` — Conformance - EC2 - master
- `ci-kubernetes-ec2-arm64-conformance-latest` — Conformance - EC2 - arm64 - master

This migrates the configs to `kubeadm.k8s.io/v1beta4`: bumps the `apiVersion` and converts `extraArgs`/`kubeletExtraArgs` from the v1beta3 `map[string]string` form to the v1beta4 list-of-`{name, value}` form (the same change [kubernetes/kubernetes#139416](https://github.com/kubernetes/kubernetes/pull/139416) made for the in-tree DRA kind config).

Files changed:
- `kubetest2-ec2/config/kubeadm-init.yaml` (Init + Cluster configurations)
- `kubetest2-ec2/config/kubeadm-join.yaml` (Join configuration)
- `kubetest2-ec2/config/al2023.sh` (inline Join configuration for Amazon Linux 2023)

#### Verification

Built `kubeadm` from current `kubernetes/master` (with v1beta3 removed) and ran `kubeadm config validate` on the rendered configs:

- v1beta3 (before): rejected with the error above.
- v1beta4 (after): `ok`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
