### PR TITLE
Bump Kubernetes on (06/09/2026)

### DIFF
--- a/vendor/k8s.io/client-go/rest/request.go
+++ b/vendor/k8s.io/client-go/rest/request.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"mime"
@@ -671,7 +672,8 @@ func (r *Request) tryThrottleWithInfo(ctx context.Context, retryInfo string) err
 	now := time.Now()
 
 	err := r.rateLimiter.Wait(ctx)
-	if err != nil {
+	// Don't wrap context errors as caller initiated ctx cancellations is not a rate limiter error.
+	if err != nil && !stderrors.Is(err, context.Canceled) && !stderrors.Is(err, context.DeadlineExceeded) {
 		err = fmt.Errorf("client rate limiter Wait returned an error: %w", err)
 	}
 	latency := time.Since(now)


### PR DESCRIPTION
PR filed with output of running hack/bump-k8s.sh on Date: 06/09/2026