### PR TITLE
Fix pod CIDR overlap with VPC CIDR and bump cilium to 1.19.6

### DIFF
--- a/kubetest2-ec2/config/run-kubeadm.sh
+++ b/kubetest2-ec2/config/run-kubeadm.sh
@@ -102,6 +102,8 @@ if [[ ${KUBEADM_CONTROL_PLANE} == true ]]; then
   LOCAL_IP=$(curl -s $META_URL/local-ipv4 --header "X-aws-ec2-metadata-token: $TOKEN")
   FIRST_TWO_OCTETS=$(echo $LOCAL_IP | cut -d'.' -f1,2)
   POD_CIDR=$(curl -s $META_URL/network/interfaces/macs/"$MAC"/vpc-ipv4-cidr-blocks --header "X-aws-ec2-metadata-token: $TOKEN" | grep "$FIRST_TWO_OCTETS.")
+  # shellcheck disable=SC2050
+  [[ "{{EXTERNAL_CLOUD_PROVIDER}}" == "external" ]] || POD_CIDR=10.244.0.0/16
 
   sed -i "s|{{BOOTSTRAP_TOKEN}}|{{KUBEADM_TOKEN}}|g" /etc/kubernetes/kubeadm-init.yaml
   EXTRA_SANS=$(curl -s --connect-timeout 3 $META_URL/public-ipv4 --header "X-aws-ec2-metadata-token: $TOKEN")

--- a/kubetest2-ec2/config/run-post-install.sh
+++ b/kubetest2-ec2/config/run-post-install.sh
@@ -15,7 +15,7 @@ if [[ "${KUBEADM_CONTROL_PLANE}" == true ]]; then
     sha256sum --check cilium-linux-${CLI_ARCH}.tar.gz.sha256sum
     tar xzvfC cilium-linux-${CLI_ARCH}.tar.gz /usr/local/bin
     rm cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
-    HOME=/root cilium install --version 1.18.4 --set cni.chainingMode=portmap --set kubeProxyReplacement=false --set socketLB.enabled=false --set sessionAffinity=true --set externalIPs.enabled=true --set nodePort.enabled=true --set hostPort.enabled=false --set cluster.name=kubernetes --set ipam.mode=kubernetes $KC
+    HOME=/root cilium install --version 1.19.6 --set cni.chainingMode=portmap --set kubeProxyReplacement=false --set socketLB.enabled=false --set sessionAffinity=true --set externalIPs.enabled=true --set nodePort.enabled=true --set hostPort.enabled=false --set cluster.name=kubernetes --set ipam.mode=kubernetes $KC
     HOME=/root cilium status --wait $KC
   fi
   # shellcheck disable=SC2050

--- a/kubetest2-ec2/pkg/deployer/runner.go
+++ b/kubetest2-ec2/pkg/deployer/runner.go
@@ -505,6 +505,7 @@ func (a *AWSRunner) getUserData(dataFile string, version string, controlPlane bo
 		data = strings.ReplaceAll(data, "{{STAGING_VERSION}}", version)
 		data = strings.ReplaceAll(data, "{{KUBEADM_TOKEN}}", a.token)
 		data = strings.ReplaceAll(data, "{{KUBEADM_CERTIFICATE_KEY}}", a.certificateKey)
+		data = strings.ReplaceAll(data, "{{EXTERNAL_CLOUD_PROVIDER}}", provider)
 		return data
 	})
 	if err != nil {


### PR DESCRIPTION
## What this fixes

The ~11% bring-up flake in the EC2 conformance jobs tracked in kubernetes/kubernetes#137793 (`[SynchronizedBeforeSuite]` timing out at 2/3 nodes ready, kubelet losing the apiserver with `no route to host` / `i/o timeout` right when the cilium pod starts).

## Root cause

`run-kubeadm.sh` sets kubeadm `podSubnet` to the **VPC CIDR** (default VPC = `172.31.0.0/16`) — a leftover from the aws-vpc-cni path where pods get real VPC IPs. With the Cilium overlay (`ipam.mode=kubernetes`), kube-controller-manager carves node pod CIDRs sequentially out of that range (`172.31.0.0/24`, `.1.0/24`, `.2.0/24`, ...) while instance IPs land randomly in the same range. Whenever an allocated pod CIDR contains another node's real IP, cilium's local node route (`enable-local-node-route=true`) on the owning node blackholes host traffic to that IP:

- sender owns the overlapping CIDR → `connect: no route to host`
- receiver owns it → replies eaten → `i/o timeout`

Evidence from run [2077761079382904832](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-ec2-arm64-conformance-latest/2077761079382904832) (2026-07-16): broken node's IP `172.31.0.7` sits in the first-allocated pod CIDR `172.31.0.0/24`; the healthy worker's cilium-agent log shows `v4Prefix=172.31.2.0/24` confirming pod CIDRs come from the VPC range. Node pod CIDR allocation is random relative to instance IPs, which is why the failure is intermittent and why it starts the moment the cilium agent installs its routes. The same overlap existed under KindNet before #499.

## Changes

- `run-kubeadm.sh`: use `10.244.0.0/16` for the overlay (cilium) path — cannot overlap the default VPC; keep the VPC CIDR for the external/aws-vpc-cni path where it is required.
- `runner.go`: substitute `{{EXTERNAL_CLOUD_PROVIDER}}` in the `FetchRunKubeadmSH` callback — the script is gzip+base64 encoded before being embedded in userdata, so the later userdata-wide `ReplaceAll` cannot reach it.
- `run-post-install.sh`: bump cilium `1.18.4` → `1.19.6` (latest stable).

## Testing

- `go build ./...` / `go vet` pass, shellcheck clean.
- Rendered `run-kubeadm.sh` with both `external` and empty provider values: `bash -n` passes, external branch keeps the VPC CIDR lookup, overlay branch renders `POD_CIDR="10.244.0.0/16"`.