### PR TITLE
Drop Python 2 compatibility from configure.sh to fix user data size

### DIFF
--- a/kubetest2-ec2/config/configure.sh
+++ b/kubetest2-ec2/config/configure.sh
@@ -19,20 +19,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [[ "$(python -V 2>&1)" =~ "Python 2" ]]; then
-  # found python2, just use that
-  PYTHON="python"
-elif [[ -f "/usr/bin/python2.7" ]]; then
-  # System python not defaulted to python 2 but using 2.7 during migration
-  PYTHON="/usr/bin/python2.7"
-else
-  # No python2 either by default, let's see if we can find python3
-  PYTHON="python3"
-  if ! command -v ${PYTHON} >/dev/null 2>&1; then
-    echo "ERROR Python not found. Aborting."
-    exit 2
-  fi
-fi
+PYTHON="python3"
 echo "Version : " $(${PYTHON} -V 2>&1)
 
 ## sysctl settings (required by Prow to avoid inotify issues)
@@ -72,11 +59,7 @@ fetch_env() {
     # Convert the yaml format file into a shell-style file.
     eval $(${PYTHON} -c '''
 import shlex,sys,yaml
-# check version of python and call methods appropriate for that version
-if sys.version_info[0] < 3:
-    items = yaml.load(sys.stdin).iteritems()
-else:
-    items = yaml.load(sys.stdin, Loader=yaml.BaseLoader).items()
+items = yaml.load(sys.stdin, Loader=yaml.BaseLoader).items()
 for k,v in items:
   print("readonly {var}={value}".format(var = k, value = shlex.quote(str(v))))
 ''' < "${tmp_env_file}" > "${CONTAINERD_HOME}/${env_file_name}")


### PR DESCRIPTION
The assembled EC2 user data (`ubuntu2604.yaml` with all scripts embedded as gzip+base64) exceeds the AWS 16384-byte limit. The latest presubmit run for `pull-kubernetes-node-e2e-alpha-ec2` failed with:

```
Error: while preparing AWS images: worker user data is too large,
must be less than 16384 bytes, is 16498
```

The size has grown over several months. The Cilium install block added to `run-post-install.sh`, the NVIDIA DRA driver blocks, the pod CIDR fix, and the Ubuntu 26.04 migration together pushed the total from about 15978 bytes (after the Cilium switch in January) to 16498 bytes today.

`configure.sh` still carries a 14-line Python 2 version detection block and a Python 2 branch inside `fetch_env`. Both are dead code on Ubuntu 26.04, which ships Python 3.14 only. Removing them saves 316 bytes in the encoded output and brings the user data down to roughly 16182 bytes, 202 bytes under the limit.

The change replaces the version detection block with `PYTHON="python3"` and removes the `if sys.version_info[0] < 3` branch from the inline Python call in `fetch_env`, keeping only the Python 3 path.

## Test plan

- [ ] Verify `pr-node-e2e-alpha-ec2` presubmit passes after this change