### PR TITLE
Drop the unused ALT tarball name when downloading containerd

### DIFF
--- a/config/configure.sh
+++ b/config/configure.sh
@@ -115,10 +115,8 @@ else
 fi
 
 TARBALL_GCS_NAME="${pkg_prefix}-${version}.linux-${ARCH}.tar.gz"
-ALT_TARBALL_GCS_NAME="${pkg_prefix}-${version}-linux-${ARCH}.tar.gz"
 # TARBALL_GCS_PATH is the path to download cri-containerd tarball for node e2e.
 TARBALL_GCS_PATH="https://storage.googleapis.com/${deploy_path}/${TARBALL_GCS_NAME}"
-ALT_TARBALL_GCS_PATH="https://storage.googleapis.com/${deploy_path}/${ALT_TARBALL_GCS_NAME}"
 # TARBALL is the name of the tarball after being downloaded.
 TARBALL="containerd.tar.gz"
 # CONTAINERD_TAR_SHA1 is the sha1sum of containerd tarball.
@@ -134,11 +132,7 @@ if [ -z "${version}" ]; then
     exit 1
   fi
 else
-  # Download and untar the release tar ball, there are two alternate names for the
-  # tar.gz files unfortunately, so this is a temporary respite until the fixes
-  # are in place
-  $(set +x; curl -X GET "${HEADERS[@]}" -f --ipv4 -Lo "${TARBALL}" --connect-timeout 20 --max-time 300 --retry 6 \
-    --retry-delay 10 "${ALT_TARBALL_GCS_PATH}") || \
+  # Download and untar the release tar ball.
   $(set +x; curl -X GET "${HEADERS[@]}" -f --ipv4 -Lo "${TARBALL}" --connect-timeout 20 --max-time 300 --retry 6 \
     --retry-delay 10 "${TARBALL_GCS_PATH}")
   tar xvf "${TARBALL}"

--- a/kubetest2-ec2/config/configure.sh
+++ b/kubetest2-ec2/config/configure.sh
@@ -107,10 +107,8 @@ else
 fi
 
 TARBALL_GCS_NAME="${pkg_prefix}-${version}.linux-${ARCH}.tar.gz"
-ALT_TARBALL_GCS_NAME="${pkg_prefix}-${version}-linux-${ARCH}.tar.gz"
 # TARBALL_GCS_PATH is the path to download cri-containerd tarball for node e2e.
 TARBALL_GCS_PATH="https://storage.googleapis.com/${deploy_path}/${TARBALL_GCS_NAME}"
-ALT_TARBALL_GCS_PATH="https://storage.googleapis.com/${deploy_path}/${ALT_TARBALL_GCS_NAME}"
 # TARBALL is the name of the tarball after being downloaded.
 TARBALL="containerd.tar.gz"
 # CONTAINERD_TAR_SHA1 is the sha1sum of containerd tarball.
@@ -126,11 +124,7 @@ if [ -z "${version}" ]; then
     exit 1
   fi
 else
-  # Download and untar the release tar ball, there are two alternate names for the
-  # tar.gz files unfortunately, so this is a temporary respite until the fixes
-  # are in place
-  $(set +x; curl -X GET "${HEADERS[@]}" -f --ipv4 -Lo "${TARBALL}" --connect-timeout 20 --max-time 300 --retry 6 \
-    --retry-delay 10 "${ALT_TARBALL_GCS_PATH}") || \
+  # Download and untar the release tar ball.
   $(set +x; curl -X GET "${HEADERS[@]}" -f --ipv4 -Lo "${TARBALL}" --connect-timeout 20 --max-time 300 --retry 6 \
     --retry-delay 10 "${TARBALL_GCS_PATH}")
   tar xvf "${TARBALL}"


### PR DESCRIPTION
Follow-up to #580.

`configure.sh` tries two names for the containerd tarball, first `ALT_TARBALL_GCS_NAME` (dash before linux, e.g. `containerd-cni-2.3.0-linux-amd64.tar.gz`) and then `TARBALL_GCS_NAME` (dot before linux, e.g. `containerd-cni-2.3.0.linux-amd64.tar.gz`). Every artifact in the staging bucket uses the dot form, so the first curl always fails and the fallback does the real download.

All EC2 jobs fetch the `containerd-main/env` file, which points at `k8s-staging-cri-tools/containerd`. A listing of that bucket shows only dot-form names across main, release-1.7, release-2.0, release-2.1, and all the presubmit pull-refs directories. The old `cri-containerd-release` bucket, where the dash form once lived, is no longer publicly readable and no EC2 job uses it.

This removes the ALT name and the double curl from both copies of `configure.sh`. It also saves another 140 bytes in the encoded user data, bringing the projected size to about 16042 bytes against the 16384-byte limit, roughly 342 bytes of headroom.

## Test plan

- [ ] Verify `pr-node-e2e-alpha-ec2` presubmit passes on this PR