### PR TITLE
Fix the AMI build: anchor populate-s3.sh to the repo and build in us-east-1

### DIFF
--- a/hack/build-ami.sh
+++ b/hack/build-ami.sh
@@ -99,7 +99,11 @@ pushd "$(go env GOPATH)/src/github.com/awslabs/amazon-eks-ami" >/dev/null
     cat <<< "$(jq --arg pause_container_image ${PAUSE_CONTAINER_IMAGE:-'registry.k8s.io/pause:3.10'} '.pause_container_image = $pause_container_image' templates/al2023/variables-default.json)" > templates/al2023/variables-default.json || true
     cat <<< "$(jq --arg containerd_version ${CONTAINERD_VERSION:-"1.7.*"} '.containerd_version = $containerd_version' templates/al2023/variables-default.json)" > templates/al2023/variables-default.json || true
 
+    # aws_region must be passed as a make variable: the Makefile always injects
+    # it into PACKER_ARGS as -var aws_region=..., which overrides the var-file,
+    # and its default (us-west-2) puts the AMI where check-ami.sh cannot find it.
     make k8s k8s=${K8S_MINOR} kubernetes_version=${KUBE_VERSION} kubernetes_build_date=${KUBE_DATE} \
+      aws_region=${AWS_REGION:-"us-east-1"} \
       pull_cni_from_github=true arch=${BUILD_EKS_AMI_ARCH:-"x86_64"} os_distro=${BUILD_EKS_AMI_OS:-"al2023"} || true
   fi
   ami_id=$(aws ec2 describe-images --region=${AWS_REGION:-"us-east-1"} --filters Name=name,Values="$AMI_NAME" --query 'Images[*].[ImageId]' --output text --max-items 1 | head -1)

--- a/hack/populate-s3.sh
+++ b/hack/populate-s3.sh
@@ -4,6 +4,9 @@ set -xeuo pipefail
 
 TEST_INFRA_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 mkdir -p "${TEST_INFRA_ROOT}/_output"
+# CI invokes this script from the kubernetes checkout; anchor all relative
+# _output paths (sha256 generation, s3 sync) to this repo, not the caller's cwd.
+cd "${TEST_INFRA_ROOT}"
 
 if [[ -z "$(which aarch64-linux-gnu-gcc)" || -z "$(which x86_64-linux-gnu-gcc)" ]]; then
   echo "Can't find aarch64-linux-gnu-gcc x86_64-linux-gnu-gcc or in PATH, please install and retry"
@@ -91,8 +94,6 @@ curl -sL https://github.com/containernetworking/cni/releases/download/v0.6.0/cni
 curl -sL https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz -o "${BIN_DIR}/linux/amd64/cni-plugins-linux-amd64-v0.8.6.tgz"
 curl -sL https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz -o "${BIN_DIR}/linux/arm64/cni-plugins-linux-arm64-v0.8.6.tgz"
 
-rm -rf _output/local/go/cache
-rm -rf _output/local/go/src
 pushd _output >/dev/null
   find . -name "*.sha256*" -delete
   find . -name "*.sha1*" -delete
@@ -109,5 +110,4 @@ pushd _output >/dev/null
 popd
 
 S3_BUCKET=${S3_BUCKET:-"provider-aws-test-infra"}
-aws s3 sync "$(pwd)/_output/" "s3://${S3_BUCKET}/"
 aws s3 sync "${TEST_INFRA_ROOT}/_output/" "s3://${S3_BUCKET}/"


### PR DESCRIPTION
Fixes the AMI build path that `ci-kubernetes-e2e-ec2-alpha-features` and `ci-kubernetes-e2e-ec2-alpha-enabled-default` run through `check-ami.sh`. Those two periodics are the only jobs that execute this path, and it has failed on every run for the whole retained history (TestGrid shows no recent greens; prow history is red back to at least May 19).

Every run dies in the packer provisioner:

```
amazon-ebs: fatal error: Unable to locate credentials
amazon-ebs: Fetching kubelet.sha256 from s3 failed, trying again with unauthenticated request.
amazon-ebs: fatal error: An error occurred (403) when calling the HeadObject operation: Forbidden
--> amazon-ebs: Script exited with non-zero exit status: 1
ami build failed, exiting...
```

**Defect 1: the versioned S3 tree has no `.sha256` files.**

`populate-s3.sh` used cwd-relative `_output` paths for the sha256 generation loop and the first `aws s3 sync`. CI invokes the script from the kubernetes checkout (the prow workdir), so the loop hashed the kubernetes `_output` tree and the versioned tree (`v1.37.0/<date>/bin/...`) uploaded with no `.sha256` files. Easy to confirm from outside AWS: `kubelet` in the bucket answers an unauthenticated GET with 200, `kubelet.sha256` answers 403.

The amazon-eks-ami `install-worker.sh` now fetches `<binary>.sha256` and runs `sha256sum -c` (the old wget-based lines that our `sed` patches neutralize are long gone), so the missing file is fatal.

Fix: `cd "${TEST_INFRA_ROOT}"` after computing it, so every relative path resolves against this repo. That also makes the first sync a duplicate of the second, so it is dropped along with the `rm -rf _output/local/go` lines that only ever trimmed the accidentally-synced kubernetes tree.

**Defect 2: packer built in us-west-2, check-ami.sh looks in us-east-1.**

The amazon-eks-ami Makefile defaults `aws_region` to us-west-2 and always injects it into `PACKER_ARGS` as `-var aws_region=...`, which overrides the var-file value we set with jq (visible in the job logs: `-var aws_region='us-west-2'`). So even a successful build would land in the wrong region and `check-ami.sh` would still report failure. Fix: pass `aws_region` as a make variable, which takes precedence over the Makefile default.

**Verification**

- Simulated the fixed flow from a foreign cwd: the versioned tree gets its `.sha256` files next to each binary and the caller's `_output` is untouched.
- `bash -n` and `shellcheck` pass on both scripts with no new findings.
- End-to-end proof will be the first periodic run after merge: the AMI build should succeed and the job should proceed to the cluster bring-up.

**Notes**

- The `Unable to locate credentials` line inside the packer instance is a separate oddity (the instance profile is attached and its role is live). It is masked in practice because the bucket objects are public-read and the unauthenticated fallback works; worth a separate look.
- `pr-node-e2e-alpha-ec2` nominally sources `check-ami.sh` too, but that presubmit does not clone this repo, so the `source` silently no-ops there. That is also why it passes while the periodics fail.