### PR TITLE
ec2: persist generated SSH key as kube_aws_rsa for e2e framework

### DIFF
--- a/kubetest2-ec2/pkg/deployer/runner.go
+++ b/kubetest2-ec2/pkg/deployer/runner.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
@@ -59,6 +60,7 @@ type AWSRunner struct {
 	certificateKey     string
 	controlPlaneIP     string
 	subnetID           string
+	sshKeyMu           sync.Mutex // guards kube_aws_rsa creation in assignNewSSHKey
 }
 
 type awsInstance struct {
@@ -656,11 +658,26 @@ func (a *AWSRunner) assignNewSSHKey(testInstance *awsInstance) error {
 		}
 	}
 	if key == nil {
-		// create our new key
-		klog.Infof("assigning new SSH key-pair for %s@%s", a.deployer.SSHUser, testInstance.publicIP)
-		key, err = utils.GenerateSSHKeypair()
+		// No pre-existing user key. Use/create the shared kube_aws_rsa key.
+		// isAWSInstanceRunning runs concurrently (one goroutine per node), so
+		// without a lock all goroutines could see no key on disk, each generate
+		// a different keypair, and write different public keys to each node's
+		// authorized_keys — leaving the e2e framework holding whichever private
+		// key won the file-write race and unable to SSH to the other nodes.
+		a.sshKeyMu.Lock()
+		if utils.LocalSSHKeyExists("kube_aws_rsa") {
+			klog.Info("loading existing kube_aws_rsa key")
+			key, err = utils.LoadExistingSSHKey("kube_aws_rsa")
+		} else {
+			klog.Infof("assigning new SSH key-pair for %s@%s", a.deployer.SSHUser, testInstance.publicIP)
+			key, err = utils.GenerateSSHKeypair()
+			if err == nil {
+				err = utils.SaveSSHKeyAs(key, "kube_aws_rsa")
+			}
+		}
+		a.sshKeyMu.Unlock()
 		if err != nil {
-			return fmt.Errorf("creating SSH key, %w", err)
+			return fmt.Errorf("error with kube_aws_rsa SSH key: %w", err)
 		}
 	}
 	testInstance.sshKey = key

--- a/kubetest2-ec2/pkg/deployer/utils/sshkey.go
+++ b/kubetest2-ec2/pkg/deployer/utils/sshkey.go
@@ -68,6 +68,25 @@ func GenerateSSHKeypair() (*TemporarySSHKey, error) {
 	}, nil
 }
 
+// SaveSSHKeyAs writes key to ~/.ssh/<keyPrefix> and ~/.ssh/<keyPrefix>.pub and
+// sets key.PrivateKeyPath, mirroring the layout that LoadExistingSSHKey expects.
+func SaveSSHKeyAs(key *TemporarySSHKey, keyPrefix string) error {
+	home := os.Getenv("HOME")
+	sshDir := home + "/.ssh"
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		return fmt.Errorf("creating .ssh dir: %w", err)
+	}
+	privPath := sshDir + "/" + keyPrefix
+	if err := os.WriteFile(privPath, key.Private, 0600); err != nil {
+		return fmt.Errorf("writing private key: %w", err)
+	}
+	if err := os.WriteFile(privPath+".pub", key.Public, 0644); err != nil {
+		return fmt.Errorf("writing public key: %w", err)
+	}
+	key.PrivateKeyPath = privPath
+	return nil
+}
+
 func LocalSSHKeyExists(keyPrefix string) bool {
 	home := os.Getenv("HOME")
 	if _, err := os.Stat(home + "/.ssh/" + keyPrefix); err == nil {


### PR DESCRIPTION
When EC2 Instance Connect is used and no pre-existing `id_rsa` or `id_ed25519` key is present, the deployer generates a new keypair per node and saves each one to a random temp file. The Kubernetes e2e framework's `GetSigner("aws")` looks for `~/.ssh/kube_aws_rsa` and has no way to find those temp files, so tests that SSH directly into nodes fail with:

```
error getting signer for provider aws:
error reading SSH key /root/.ssh/kube_aws_rsa: no such file or directory
```

This has been breaking the NFS host-cleanup tests in `ci-kubernetes-e2e-ec2-alpha-enabled-default` since those tests lost their `[Flaky]` skip tag.

**What this change does**

Adds a `SaveSSHKeyAs` helper to `utils/sshkey.go` that writes a keypair to `~/.ssh/<prefix>` and `~/.ssh/<prefix>.pub`, matching the layout that `LoadExistingSSHKey` already reads.

In `assignNewSSHKey`, when no `id_rsa` or `id_ed25519` key exists, the deployer now generates one keypair, saves it to `~/.ssh/kube_aws_rsa`, and reuses that same key for every other node. `isAWSInstanceRunning` runs concurrently, one goroutine per node, so the generate-and-save step is protected by a `sync.Mutex` on `AWSRunner`. Without the lock, all goroutines could generate different keys, write different public keys to each node's `authorized_keys`, and leave the e2e framework with whichever private key happened to win the file write, unable to SSH to the other nodes.

The result is that all nodes share one key, each node's `authorized_keys` has that key's public half, and `~/.ssh/kube_aws_rsa` holds the private half where the e2e framework can find it.

**Testing**

The fix is exercised by `ci-kubernetes-e2e-ec2-alpha-enabled-default`. The two NFS host-cleanup tests should pass once this change is picked up by the job.