### PR TITLE
ec2: make SSH-based e2e tests work through a control plane bastion

### DIFF
--- a/kubetest2-ec2/pkg/deployer/runner.go
+++ b/kubetest2-ec2/pkg/deployer/runner.go
@@ -605,6 +605,11 @@ func (a *AWSRunner) createAWSInstance(img utils.InternalAWSImage) (*awsInstance,
 		if err != nil {
 			return nil, fmt.Errorf("picking subnet: %w in vpc (%s)", err, vpcID)
 		}
+		// Best effort: the KUBE_SSH_BASTION hop needs tcp/22 between
+		// instances; do not fail if the CI role cannot edit the group.
+		if err := utils.EnsureSSHSelfIngress(a.ec2Service, vpcID); err != nil {
+			klog.Warningf("could not ensure ssh ingress within default security group: %v", err)
+		}
 	}
 
 	var instance *ec2typesv2.Instance

--- a/kubetest2-ec2/pkg/deployer/up.go
+++ b/kubetest2-ec2/pkg/deployer/up.go
@@ -168,6 +168,20 @@ func (d *deployer) Up() error {
 		return err
 	}
 
+	// EC2 nodes advertise only an InternalIP, which the k8s e2e framework
+	// cannot dial from outside the VPC ("No ssh-able nodes"). Route the
+	// framework's SSH through the control plane as a bastion: every node
+	// trusts the shared key that assignNewSSHKey persisted, and the ginkgo
+	// tester subprocess inherits these env vars.
+	if len(runner.instances) > 0 && runner.instances[0].publicIP != "" {
+		if _, ok := os.LookupEnv("KUBE_SSH_BASTION"); !ok {
+			os.Setenv("KUBE_SSH_BASTION", runner.instances[0].publicIP+":22")
+		}
+		if _, ok := os.LookupEnv("KUBE_SSH_USER"); !ok {
+			os.Setenv("KUBE_SSH_USER", d.SSHUser)
+		}
+	}
+
 	d.waitForKubectlNodes()
 	d.waitForKubectlNodesToBeReady()
 

--- a/kubetest2-ec2/pkg/deployer/utils/ec2.go
+++ b/kubetest2-ec2/pkg/deployer/utils/ec2.go
@@ -110,6 +110,45 @@ func LaunchNewInstance(ec2Service *ec2v2.Client, iamService *iamv2.Client,
 	return WaitForInstanceToRun(ec2Service, &rsv.Instances[0]), nil
 }
 
+// EnsureSSHSelfIngress allows TCP 22 between instances that share the VPC's
+// default security group (instances launch without an explicit group, so they
+// all land in it). The e2e framework reaches worker nodes by tunneling SSH
+// through the control plane (KUBE_SSH_BASTION); that second hop targets a
+// node's private IP and only a security group rule can admit it. A rule that
+// already exists returns InvalidPermission.Duplicate, which counts as success.
+func EnsureSSHSelfIngress(svc *ec2v2.Client, vpcID string) error {
+	out, err := svc.DescribeSecurityGroups(context.TODO(), &ec2v2.DescribeSecurityGroupsInput{
+		Filters: []ec2typesv2.Filter{
+			{Name: awsv2.String("vpc-id"), Values: []string{vpcID}},
+			{Name: awsv2.String("group-name"), Values: []string{"default"}},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("describing default security group of vpc %s: %w", vpcID, err)
+	}
+	if len(out.SecurityGroups) == 0 {
+		return fmt.Errorf("no default security group in vpc %s", vpcID)
+	}
+	groupID := out.SecurityGroups[0].GroupId
+	_, err = svc.AuthorizeSecurityGroupIngress(context.TODO(), &ec2v2.AuthorizeSecurityGroupIngressInput{
+		GroupId: groupID,
+		IpPermissions: []ec2typesv2.IpPermission{{
+			IpProtocol:       awsv2.String("tcp"),
+			FromPort:         awsv2.Int32(22),
+			ToPort:           awsv2.Int32(22),
+			UserIdGroupPairs: []ec2typesv2.UserIdGroupPair{{GroupId: groupID}},
+		}},
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "InvalidPermission.Duplicate") {
+			return nil
+		}
+		return fmt.Errorf("authorizing ssh ingress on security group %s: %w", *groupID, err)
+	}
+	klog.Infof("allowed ssh (tcp/22) between instances in security group %s", *groupID)
+	return nil
+}
+
 func WaitForInstanceToRun(ec2Service *ec2v2.Client, instance *ec2typesv2.Instance) *ec2typesv2.Instance {
 	for i := 0; i < 30; i++ {
 		if i > 0 {


### PR DESCRIPTION
The periodic job ci-kubernetes-e2e-ec2-alpha-features has failed since 2026-08-02 with:

```
[FAILED] No ssh-able nodes
In [It] at: k8s.io/kubernetes/test/e2e/network/networking.go:554
```

Tests that SSH into nodes were silently skipped before commit 848d043d, because the e2e framework could not find /root/.ssh/kube_aws_rsa. The junit file of the last green run shows the failing test as "skipped - No SSH Key for provider aws". Commit 848d043d persisted the key, so the framework now runs the test, and the test fails because the framework cannot reach the nodes. EC2 nodes advertise only an internal IP on the Node object. The framework dials port 22 on that internal IP and gives up after three seconds. The Prow pod is outside the VPC, so every dial times out.

The first commit routes the framework's SSH through the control plane. After all instances are running, Up() exports KUBE_SSH_BASTION with the control plane public IP and port 22, and KUBE_SSH_USER with the deployer SSH user. When KUBE_SSH_BASTION is set, the framework skips the direct dial and opens SSH to each node through the bastion. Both hops authenticate with the shared kube_aws_rsa key, which assignNewSSHKey already writes to the authorized_keys file on every node, so the key keeps working after the 60 seconds that EC2 Instance Connect allows. The ginkgo tester runs as a child process of kubetest2 and inherits both variables. The deployer sets each variable only when the variable is not already set.

The second commit covers the bastion's second hop, where the control plane connects to each worker node on port 22 at its private IP. Instances launch without an explicit security group, so they all share the VPC's default security group. The deployer now adds a self-referencing ingress rule for tcp/22 to that group after picking the subnet. A duplicate rule counts as success, and a permission failure only logs a warning, since most default groups already allow this traffic.

I verified both commits with go build and go vet. kubernetes/test-infra#37603 adds pull-kubernetes-e2e-ec2-alpha-canary, a presubmit that mirrors the periodic and builds kubetest2-ec2 from the pull request checkout. After that job merges, I will run it on this pull request to reproduce the failing scenario and confirm the fix.
