### PR TITLE
Disable PMD-size THP for arm64 Ubuntu 26.04 instances

### DIFF
--- a/config/ubuntu2604.yaml
+++ b/config/ubuntu2604.yaml
@@ -72,6 +72,7 @@ runcmd:
   - sudo rm -f /usr/lib/systemd/logind.conf.d/unattended-upgrades-logind-maxdelay.conf
   - sudo systemctl restart systemd-logind
   - sysctl -w kernel.apparmor_restrict_unprivileged_unconfined=0 || true
+  - '[ "$(uname -m)" != "aarch64" ] || echo never > /sys/kernel/mm/transparent_hugepage/hugepages-2048kB/enabled || true'
   # Stop the existing containerd service if there is one. (for Docker 18.09+)
   - systemctl is-active containerd && systemctl stop containerd
   - systemctl daemon-reload

--- a/kubetest2-ec2/config/ubuntu2604.yaml
+++ b/kubetest2-ec2/config/ubuntu2604.yaml
@@ -96,6 +96,7 @@ runcmd:
   - systemctl restart systemd-resolved
   - rm -f /usr/lib/systemd/logind.conf.d/unattended-upgrades-logind-maxdelay.conf
   - systemctl restart systemd-logind
+  - '[ "$(uname -m)" != "aarch64" ] || echo never > /sys/kernel/mm/transparent_hugepage/hugepages-2048kB/enabled || true'
   - systemctl daemon-reload
   - systemctl enable containerd-installation.service
   - systemctl enable containerd.service


### PR DESCRIPTION
## What

Adds one aarch64-guarded `runcmd` entry to both `ubuntu2604.yaml` userdata files (node e2e and kubetest2-ec2) that sets `/sys/kernel/mm/transparent_hugepage/hugepages-2048kB/enabled` to `never` before containerd starts. amd64 instances are untouched.

## Why

`ci-containerd-node-arm64-e2e-serial-ec2` has failed every OOMKiller test run since 2026-07-29, when these jobs moved to Ubuntu 26.04 (#580 area, commit 0b5a44de04). Triage cluster: https://go.k8s.io/triage#c75c5c29b7f424ca15a2

Root cause is not the kernel and not the AMI: **glibc 2.43 (shipped in Ubuntu 26.04) enables malloc transparent huge pages by default on aarch64 only** ([Phoronix](https://www.phoronix.com/news/Glibc-malloc-2MB-THP-AArch64)). malloc madvises `MADV_HUGEPAGE` onto its 64MB-aligned per-thread arena heaps even when `glibc.malloc.hugetlb` is unset. runc is dynamically linked and multithreaded, so `runc:[2:INIT]` (running against the host glibc) picks up 4-6 x 2MB THPs, inflating its charged anon by ~8-12MB. Containers with small memory limits (the OOMKiller tests use 15Mi) are OOM-killed during `runc create`, and containerd reports exit 128/`StartError` instead of the expected 137/`OOMKilled`.

Why the sysfs knob instead of the tunable: `GLIBC_TUNABLES=glibc.malloc.hugetlb=0` does disable this, but runc execs its init with an empty environment, so no env-based opt-out can reach the process that matters. Until runc or glibc grow a usable opt-out, the per-size sysfs knob is the only lever that works, and scoping it to the PMD size on aarch64 keeps the blast radius minimal.

## Validation

Reproduced and validated on GCP Ubuntu 26.04 instances (both arches, kernel 7.0.0-1008-gcp, glibc 2.43) with the same containerd main bundle these jobs use:

- arm64 default: `runc:[2:INIT]` shows 8192kB AnonHugePages across 4 VMAs flagged `VM_HUGEPAGE`, cgroup `memory.current` ~11MB; amd64: zero
- a pure-C 8-thread malloc reproducer picks up 16MB of THP by default on arm64, 0 on amd64
- with `hugepages-2048kB/enabled=never`: init drops to AnonHugePages=0, `memory.current` 2.7MB; the C reproducer drops to 0

## Follow-ups (separate)

- k/k: raise OOMKiller test limits (15Mi is within the new runtime overhead margin on affected hosts)
- upstream reports to runc (inject the tunable for init) and glibc (no per-process opt-out reaches env-scrubbed processes)
- the PSI memory-pressure test failures on these same jobs are a separate kernel-side issue, not fixed by this